### PR TITLE
Update contact information

### DIFF
--- a/downloads/drule.c
+++ b/downloads/drule.c
@@ -12,7 +12,7 @@
 /* legally possible, the right is granted to use the work for any purpose,   */
 /* without any conditions, unless such conditions are required by law.       */
 /*                                                                           */
-/* Norman Megill nm(at)alum(dot)mit(dot)edu                                  */
+/* Norman Megill                                                             */
 /*****************************************************************************/
 
 /* History:

--- a/email.html
+++ b/email.html
@@ -7,14 +7,8 @@
 <META NAME="viewport" CONTENT="width=device-width, initial-scale=1.0">
 
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
-<TITLE>Email Norman Megill</TITLE>
+<TITLE>Contact Metamath</TITLE>
 <LINK REL="shortcut icon" HREF="favicon.ico" TYPE="image/x-icon">
-
-<STYLE TYPE="text/css">
-<!--
-/*hr {color:#FFBF72;background-color:#FFBF72;height:1px;border-style:none;}*/
--->
-</STYLE>
 
 </HEAD>
 
@@ -27,7 +21,7 @@ FACE=sans-serif><A HREF="index.html"><IMG SRC="mm.gif" BORDER=0
 ALT="Home" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>Metamath Home</A></FONT></TD>
 
 <TD ALIGN=center NOWRAP><FONT SIZE="+3"
-COLOR="#006633"><B>Email</B></FONT>
+COLOR="#006633"><B>Contact us</B></FONT>
 </TD>
 
 <TD ALIGN=right VALIGN=top WIDTH="25%">&nbsp;</TD>
@@ -37,71 +31,23 @@ COLOR="#006633"><B>Email</B></FONT>
 
 <HR NOSHADE SIZE=1>
 
-<!-- <CENTER> -->
+<p>The two best ways to contact the metamath project are:</p>
 
+<ol>
+  <li>Via the <a href="mm-mailing-list.html" >metamath mailing list</a>.</li>
+  <li>By creating a github issue (most often in the
+  <a href="https://github.com/metamath/set.mm" >set.mm</a> repository but we
+  also list related repositories at <a href="other.html" >other.html</a> and
+  some are in the <a href="https://github.com/metamath" >the metmath github
+  organization</a>).</li>
+</ol>
 
-<!--
-<B>Please note that I will not be able to respond to email
- from June 28 through July 5.
-- Norm</B><P>
--->
+<p>By asking questions in public you increase the chances of reaching
+someone with the time and ability to respond.</p>
 
-
-You can email Norman Megill at
-"<FONT COLOR=BLUE>nm at alum period mit period edu</FONT>" with
-"at" and "period" replaced by the corresponding characters.
-
-
-<P> Your first email should include "Metamath" in the subject to add you
-to my spam filter's whitelist.
-
-
-<!--
-<P>You can also contact me
- via <A HREF="http://xri.net/=nm">=nm</A> (which is my permanent
-<A HREF="http://en.wikipedia.org/wiki/I-name">i-name</A>).
--->
-<!-- <A HREF="http://xdi.org/">i-name</A>). -->
-<!--
-<B>Include your email address inside your message, because
-otherwise I will have no way to contact you.</B>
--->
-
-
-<P> When possible, I prefer plain text email (not <A
-HREF="http://www.efn.no/html-bad.html">HTML formatted</A>).
-
-<P>
-<HR NOSHADE SIZE=1>
-
-<B>For gmail.com users</B>
-
-<P>As of September, 2018, Google seems to have put me on some kind of
-blacklist and has been bouncing many of my emails to gmail.com as spam.
-The following procedure to add me (nm at alum dot mit dot edu) to
-gmail's white list seems to have solved the problem in one case:
-
-<P><A HREF="https://www.labnol.org/internet/gmail-whitelist/19754/"
->How to Setup a Whitelist in Gmail</A>
-
-<P>I would recommend doing that if you email me from a gmail
-address (and want a response).
-
-
- <P> <HR NOSHADE SIZE=1> <P> My postal address is:
-<P>Norman Megill
-<BR>93 Bridge St.
-<BR>Lexington, MA 02421-7946
-<BR> USA
-
-<!-- <SCRIPT SRC="http://www.google-analytics.com/urchin.js" TYPE="text/javascript">
-</SCRIPT>
-<SCRIPT TYPE="text/javascript">
-_uacct = "UA-1862729-1";
-urchinTracker();
-</SCRIPT>
--->
-
+<p>However, the individuals listed in the <a
+href="https://github.com/metamath/set.mm/blob/develop/CONTRIBUTING.md">CONTRIBUTING</a>
+file are also willing to be contacted individually.</p>
 
 <P>
 <HR NOSHADE SIZE=1>

--- a/email.html
+++ b/email.html
@@ -31,14 +31,14 @@ COLOR="#006633"><B>Contact us</B></FONT>
 
 <HR NOSHADE SIZE=1>
 
-<p>The two best ways to contact the metamath project are:</p>
+<p>The two best ways to contact the Metamath project are:</p>
 
 <ol>
-  <li>Via the <a href="mm-mailing-list.html" >metamath mailing list</a>.</li>
-  <li>By creating a github issue (most often in the
+  <li>Via the <a href="mm-mailing-list.html" >Metamath mailing list</a>.</li>
+  <li>By creating a GitHub issue (most often in the
   <a href="https://github.com/metamath/set.mm" >set.mm</a> repository but we
   also list related repositories at <a href="other.html" >other.html</a> and
-  some are in the <a href="https://github.com/metamath" >the metmath github
+  some are in the <a href="https://github.com/metamath" >the Metamath GitHub
   organization</a>).</li>
 </ol>
 

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,9 @@
 # The script is intended to be robust in that it can be re-run if
 # it is aborted in the middle.
 #
-# Please report any problems to "nm at alum.mit.edu" (change " at " to "@").
+# Please report any problems via github issue at
+# https://github.com/metamath/metamath-website-seed
+# or via the contact methods at https://us.metamath.org/email.html
 #
 ##############################################################################
 # (The following notes are intended for N. Megill only)

--- a/metamath/miu.mm
+++ b/metamath/miu.mm
@@ -6,7 +6,7 @@ $(
 This work is waived of all rights, including copyright, according to the CC0
 Public Domain Dedication.  http://creativecommons.org/publicdomain/zero/1.0/
 
-Norman Megill - email: nm at alum.mit.edu
+Norman Megill
 
 $)
 

--- a/other.html
+++ b/other.html
@@ -61,8 +61,8 @@ img { margin-bottom: -4px }
 -->
 
 This page collects supplementary material related to Metamath.  If you have
-a topic you wish to add, contact <A
-HREF="../email.html">Norm Megill</A>.
+a topic you wish to add, <A
+HREF="email.html">contact us</A>.
 
 
 <HR NOSHADE SIZE=1>

--- a/rdme-home.txt
+++ b/rdme-home.txt
@@ -10,4 +10,4 @@ licensing information that applies to the content of this package.  The
 file is also at http://us.metamath.org/copyright.html on the web.
 
 
-Norm Megill nm (at) alum.mit.edu    30-May-05
+Norm Megill        30-May-05


### PR DESCRIPTION
There are many places on the web site which contain Norm's email address and this doesn't fix all of them but most notably it fixes email.html (which a lot of things link to) and a number of the references I was able to find (especially ones with a call to action such as "please report problems to").