### PR TITLE
Remove notice about mm-lamp dependency on @expln/utils.

### DIFF
--- a/other.html
+++ b/other.html
@@ -491,9 +491,7 @@ You can
 >try out metamath-lamp from your web browser (this redirects to the current version)</a>
 You can also check out the
 <a href="https://github.com/expln/metamath-lamp"
->metamath-lamp source code repository (MIT license)</a>; note that it depends
-<a href="https://github.com/expln/rescript-utils"
->@expln/utils npm module</a>.
+>metamath-lamp source code repository (MIT license)</a>.
 When you'll need to select and load a database; you can even download
 set.mm from the metamath.org website (so you don't need a local copy).
 It has various nice capabilities like parentheses autocompletion,


### PR DESCRIPTION
This PR reflects corresponding changes in mm-lamp repository: I removed @expln/utils from dependencies of mm-lamp.