### PR TITLE
don't line break between `<IMG` and `SRC=`

### DIFF
--- a/award2003.html
+++ b/award2003.html
@@ -403,13 +403,10 @@ can
 
 
 <IMG SRC='mpeuni/_vdash.gif' WIDTH=10
-HEIGHT=19 ALT='|-' ALIGN=TOP> <IMG
-SRC='mpeuni/exists.gif' WIDTH=9 HEIGHT=19
-ALT='E.'  ALIGN=TOP><IMG
-SRC='mpeuni/_x.gif' WIDTH=10 HEIGHT=19
+HEIGHT=19 ALT='|-' ALIGN=TOP> <IMG SRC='mpeuni/exists.gif' WIDTH=9 HEIGHT=19
+ALT='E.'  ALIGN=TOP><IMG SRC='mpeuni/_x.gif' WIDTH=10 HEIGHT=19
 ALT='x' ALIGN=TOP> <IMG SRC='mpeuni/_x.gif'
-WIDTH=10 HEIGHT=19 ALT='x' ALIGN=TOP> <IMG
-SRC='mpeuni/eq.gif' WIDTH=12 HEIGHT=19
+WIDTH=10 HEIGHT=19 ALT='x' ALIGN=TOP> <IMG SRC='mpeuni/eq.gif' WIDTH=12 HEIGHT=19
 ALT='=' ALIGN=TOP> <IMG SRC='mpeuni/_x.gif'
 WIDTH=10 HEIGHT=19 ALT='x' ALIGN=TOP> &nbsp;
 
@@ -417,13 +414,10 @@ WIDTH=10 HEIGHT=19 ALT='x' ALIGN=TOP> &nbsp;
 HEIGHT=19 ALT='=&gt;' ALIGN=TOP>
 
 &nbsp; <IMG SRC='mpeuni/_vdash.gif'
-WIDTH=10 HEIGHT=19 ALT='|-' ALIGN=TOP> <IMG
-SRC='mpeuni/exists.gif' WIDTH=9 HEIGHT=19
-ALT='E.'  ALIGN=TOP><IMG
-SRC='mpeuni/_y.gif' WIDTH=9 HEIGHT=19
+WIDTH=10 HEIGHT=19 ALT='|-' ALIGN=TOP> <IMG SRC='mpeuni/exists.gif' WIDTH=9 HEIGHT=19
+ALT='E.'  ALIGN=TOP><IMG SRC='mpeuni/_y.gif' WIDTH=9 HEIGHT=19
 ALT='y' ALIGN=TOP> <IMG SRC='mpeuni/_y.gif'
-WIDTH=9 HEIGHT=19 ALT='y' ALIGN=TOP> <IMG
-SRC='mpeuni/eq.gif' WIDTH=12 HEIGHT=19
+WIDTH=9 HEIGHT=19 ALT='y' ALIGN=TOP> <IMG SRC='mpeuni/eq.gif' WIDTH=12 HEIGHT=19
 ALT='=' ALIGN=TOP> <IMG SRC='mpeuni/_y.gif'
 WIDTH=9 HEIGHT=19 ALT='y' ALIGN=TOP>
 

--- a/donations.html
+++ b/donations.html
@@ -19,8 +19,7 @@
 <TABLE BORDER=0 WIDTH="100%"><TR>
 
 <TD ALIGN=left VALIGN=middle WIDTH="25%"><FONT SIZE=-2
-FACE=sans-serif><A HREF="index.html"><IMG
-SRC="mm.gif" BORDER=0
+FACE=sans-serif><A HREF="index.html"><IMG SRC="mm.gif" BORDER=0
 ALT="Home" HEIGHT=32 WIDTH=32 ALIGN=MIDDLE>Metamath Home</A></FONT></TD>
 
 <TD ALIGN=center NOWRAP><FONT SIZE="+3"

--- a/index.html
+++ b/index.html
@@ -722,8 +722,8 @@ called a metamathematician, so to avoid confusion
 
 
 <!--
-<P><A NAME="if"></A><FONT COLOR="#006633"><B>Q:</B> The symbol "<IMG
-SRC='mpeuni/_if.gif' WIDTH=11 HEIGHT=19 ALT='if' ALIGN=TOP>" shows up
+<P><A NAME="if"></A><FONT COLOR="#006633"><B>Q:</B> The symbol
+"<IMG SRC='mpeuni/_if.gif' WIDTH=11 HEIGHT=19 ALT='if' ALIGN=TOP>" shows up
 in some set theory proofs such as <A HREF="mpeuni/redivclz.html">this
 one</A>.  What does it mean?</FONT><BR>
 
@@ -1622,20 +1622,20 @@ COLOR="#006633" SIZE="+1">Reviews</FONT></B></TD></TR>
 
 <!--
 <TD ALIGN=CENTER><A
-HREF="http://mathforge.net/index.jsp?page=seeReplies&amp;messageNum=325"> <IMG
-SRC="_dir_mathforge.gif" ALT="MathForge logo" BORDER=0 WIDTH=100
+HREF="http://mathforge.net/index.jsp?page=seeReplies&amp;messageNum=325">
+<IMG SRC="_dir_mathforge.gif" ALT="MathForge logo" BORDER=0 WIDTH=100
 HEIGHT=48></A><P><FONT SIZE=-1>MathForge (Jan. 23, 2004)</FONT></TD>
 -->
 
 <TD ALIGN=CENTER><A
-HREF="http://www.theassayer.org/cgi-bin/asbook.cgi?book=794"> <IMG
-SRC="_dir_assayer.gif" ALT="The Assayer logo" BORDER=0 WIDTH=77
+HREF="http://www.theassayer.org/cgi-bin/asbook.cgi?book=794">
+<IMG SRC="_dir_assayer.gif" ALT="The Assayer logo" BORDER=0 WIDTH=77
 HEIGHT=76></A><P><FONT SIZE=-1>The Assayer open-content book
 reviews (Jan. 8, 2004)</FONT></TD>
 
 <TD ALIGN=CENTER><A
-HREF="http://www.math.uwaterloo.ca/navigation/ideas/reviews/metamath.shtml"> <IMG
-SRC="_dir_waterloo.gif" ALT="U Waterloo logo" BORDER=0 WIDTH=97
+HREF="http://www.math.uwaterloo.ca/navigation/ideas/reviews/metamath.shtml">
+<IMG SRC="_dir_waterloo.gif" ALT="U Waterloo logo" BORDER=0 WIDTH=97
 HEIGHT=66></A><P><FONT SIZE=-1>University of Waterloo<BR>
 Archimedes' Sandbox Reviews (Oct. 28, 2002)</FONT></TD>
 
@@ -1707,8 +1707,7 @@ Education Portal</FONT></TD>
 
 <TD ALIGN=CENTER><A
 HREF="http://www.britannica.com/search?query=set+theory&amp;submit=Find">
- <IMG
-SRC="_dir_britannica.gif" ALT="Britannica logo" BORDER=0 WIDTH=114
+ <IMG SRC="_dir_britannica.gif" ALT="Britannica logo" BORDER=0 WIDTH=114
 HEIGHT=30></A><P><FONT SIZE=-1>Encyclop&aelig;dia Britannica "approved
 iGuide site" (Oct. 11, 2006) (free
 <A
@@ -1743,8 +1742,8 @@ WIDTH=71 HEIGHT=48></A><P><FONT SIZE=-1>Science Search
 
 <!--
 <TD ALIGN=CENTER><A
-HREF="http://www.backflip.com/members/mabullas/11969127/sort=0/"> <IMG
-SRC="_dir_backflip.gif" ALT="Backflip logo" BORDER=0 WIDTH=161
+HREF="http://www.backflip.com/members/mabullas/11969127/sort=0/">
+<IMG SRC="_dir_backflip.gif" ALT="Backflip logo" BORDER=0 WIDTH=161
 HEIGHT=40></A><P><FONT SIZE=-1>Backflip</FONT></TD>
 -->
 
@@ -1765,16 +1764,16 @@ Mathematics, and Computing</FONT></TD>
 -->
 
 <!--
-<TD ALIGN=CENTER><A HREF="http://www.utyx.com/math/logic.html"> <IMG
-SRC="_dir_utyx.gif" ALT="UTYX.com logo" BORDER=0 WIDTH=134
+<TD ALIGN=CENTER><A HREF="http://www.utyx.com/math/logic.html">
+<IMG SRC="_dir_utyx.gif" ALT="UTYX.com logo" BORDER=0 WIDTH=134
 HEIGHT=20></A><P><FONT SIZE=-1>Math-related news, books, and web
 resources</FONT></TD>
 -->
 
 <!--
 <TD ALIGN=CENTER><A
-HREF="http://www.openhere.com/science/mathematics/set-theory/"> <IMG
-SRC="_dir_openhere.gif" ALT="OpenHere logo" BORDER=0 WIDTH=100
+HREF="http://www.openhere.com/science/mathematics/set-theory/">
+<IMG SRC="_dir_openhere.gif" ALT="OpenHere logo" BORDER=0 WIDTH=100
 HEIGHT=67></A><P><FONT SIZE=-1>OpenHere Network</FONT></TD>
 -->
 
@@ -1796,15 +1795,15 @@ COLOR="#006633" SIZE="+1">Awards</FONT></B></TD></TR>
 
 <TR>
 
-<TD ALIGN=CENTER><A HREF="http://www.house-sparrow.com/2000.htm"> <IMG
-SRC="_award_sparrow.gif" ALT="Golden House Sparrow Award" BORDER=0
+<TD ALIGN=CENTER><A HREF="http://www.house-sparrow.com/2000.htm">
+<IMG SRC="_award_sparrow.gif" ALT="Golden House Sparrow Award" BORDER=0
 WIDTH=120 HEIGHT=69></A><P><FONT SIZE=-1>The Golden House Sparrow Award:
 Site of the Day (Jul. 20, 2000) (check out their eclectic <A
 HREF="http://www.hedweb.com/siteoday/2008.htm">current
 page</A>)</FONT></TD>
 
-<TD ALIGN=CENTER><A HREF="http://scout.cs.wisc.edu/Archives/SPT--FullRecord.php?ResourceId=7030"> <IMG
-SRC="_award_scout.gif" ALT="Scout Report for Science and Engineering"
+<TD ALIGN=CENTER><A HREF="http://scout.cs.wisc.edu/Archives/SPT--FullRecord.php?ResourceId=7030">
+<IMG SRC="_award_scout.gif" ALT="Scout Report for Science and Engineering"
 BORDER=0 WIDTH=125 HEIGHT=49></A><P><FONT SIZE=-1>Scout
 Report for Science and Engineering Selection (Jul. 19, 2000)</FONT></TD>
 

--- a/mm.html
+++ b/mm.html
@@ -139,8 +139,8 @@ Please select a mirror site to reach the Metamath Home Page.
 
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://us.metamath.org/index.html"><img
-SRC="_flag-us.png" WIDTH=64 HEIGHT=32 ALT="US" ALIGN=middle BORDER=0></A>
+HREF="http://us.metamath.org/index.html"><IMG SRC="_flag-us.png"
+WIDTH=64 HEIGHT=32 ALT="US" ALIGN=middle BORDER=0></A>
 </TD><TD>
 
 <A TARGET="_top"
@@ -161,8 +161,8 @@ Web server
 <!-- uncomment to display ssl.metamath.org
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://ssl.metamath.org/index.html"><img
-SRC="_flag-us.png" WIDTH=64 HEIGHT=32 ALT="US" ALIGN=middle BORDER=0></A>
+HREF="http://ssl.metamath.org/index.html"><IMG SRC="_flag-us.png"
+WIDTH=64 HEIGHT=32 ALT="US" ALIGN=middle BORDER=0></A>
 </TD><TD>
 
 <A TARGET="_top"
@@ -176,8 +176,8 @@ HREF="https://ssl.metamath.org/index.html">ssl.metamath.org</A>
 <!--
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://gr.metamath.org/index.html"><img
-SRC="_flag-gr.png" WIDTH=64 HEIGHT=32 ALT="GR" ALIGN=middle BORDER=0></A>
+HREF="http://gr.metamath.org/index.html"><IMG SRC="_flag-gr.png"
+WIDTH=64 HEIGHT=32 ALT="GR" ALIGN=middle BORDER=0></A>
 </TD><TD>
 <A TARGET="_top"
 HREF="http://gr.metamath.org/index.html">gr.metamath.org</A>
@@ -194,8 +194,8 @@ HREF="http://www.ieee.aegean.gr/">IEEE Student Branch of the
 <!-- No longer being updated:
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://at.metamath.org/index.html"><img
-SRC="_flag-at.png" WIDTH=64 HEIGHT=32 ALT="AT" ALIGN=middle BORDER=0></A>
+HREF="http://at.metamath.org/index.html"><IMG SRC="_flag-at.png"
+WIDTH=64 HEIGHT=32 ALT="AT" ALIGN=middle BORDER=0></A>
 </TD><TD>
 <A TARGET="_top"
 HREF="http://at.metamath.org/index.html">at.metamath.org</A>
@@ -229,8 +229,8 @@ HREF="http://caiyunapp.com/">caiyunapp.com</A>]
 <!--
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://de.metamath.org/index.html"><img
-SRC="_flag-de.png" WIDTH=64 HEIGHT=32 ALT="DE" ALIGN=middle BORDER=0></A>
+HREF="http://de.metamath.org/index.html"><IMG SRC="_flag-de.png"
+WIDTH=64 HEIGHT=32 ALT="DE" ALIGN=middle BORDER=0></A>
 </TD><TD>
 <A TARGET="_top"
 HREF="http://de.metamath.org/index.html">de.metamath.org</A>
@@ -277,8 +277,8 @@ HREF="http://de.metamath.org/index.html">de.metamath.org</A>
 <!--
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://kr.metamath.org/index.html"><img
-SRC="_flag-kr.gif" WIDTH=64 HEIGHT=32 ALT="KR" ALIGN=middle BORDER=0></A>
+HREF="http://kr.metamath.org/index.html"><IMG SRC="_flag-kr.gif"
+WIDTH=64 HEIGHT=32 ALT="KR" ALIGN=middle BORDER=0></A>
 </TD><TD>
 <A TARGET="_top"
 HREF="http://kr.metamath.org/index.html">kr.metamath.org</A>
@@ -294,8 +294,8 @@ HREF="http://0xf.kr/">0xf.kr</A>]
 <!--
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://gr2.metamath.org/index.html"><img
-SRC="_flag-gr.png" WIDTH=64 HEIGHT=32 ALT="GR" ALIGN=middle BORDER=0></A>
+HREF="http://gr2.metamath.org/index.html"><IMG SRC="_flag-gr.png"
+WIDTH=64 HEIGHT=32 ALT="GR" ALIGN=middle BORDER=0></A>
 </TD><TD>
 <A TARGET="_top"
 HREF="http://gr2.metamath.org/index.html">gr2.metamath.org</A>
@@ -307,8 +307,8 @@ HREF="http://gr2.metamath.org/index.html">gr2.metamath.org</A>
 <!--
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://us3.metamath.org/index.html"><img
-SRC="_flag-us.png" WIDTH=64 HEIGHT=32 ALT="US" ALIGN=middle BORDER=0></A>
+HREF="http://us3.metamath.org/index.html"><IMG SRC="_flag-us.png"
+WIDTH=64 HEIGHT=32 ALT="US" ALIGN=middle BORDER=0></A>
 </TD><TD>
 <A TARGET="_top"
 HREF="http://us3.metamath.org/index.html">us3.metamath.org</A>
@@ -319,8 +319,8 @@ HREF="http://us3.metamath.org/index.html">us3.metamath.org</A>
 <!--
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://metamath.mirror.aarnet.edu.au/index.html"><img
-SRC="_flag-nz.png" WIDTH=64 HEIGHT=32 ALT="NZ" ALIGN=middle BORDER=0></A>
+HREF="http://metamath.mirror.aarnet.edu.au/index.html"><IMG SRC="_flag-nz.png"
+WIDTH=64 HEIGHT=32 ALT="NZ" ALIGN=middle BORDER=0></A>
 </TD><TD>
 
 <A TARGET="_top"
@@ -333,9 +333,8 @@ HREF="http://metamath.mirror.aarnet.edu.au/index.html"
 <!--
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://mirrors.hostlogix.net/www.metamath.org/index.html"><img
-SRC="_flag-pirate.png" WIDTH=64 HEIGHT=32 ALT="Unofficial"
-ALIGN=middle BORDER=0></A>
+HREF="http://mirrors.hostlogix.net/www.metamath.org/index.html"><IMG SRC="_flag-pirate.png"
+WIDTH=64 HEIGHT=32 ALT="Unofficial" ALIGN=middle BORDER=0></A>
 </TD><TD>
 
 <A TARGET="_top"
@@ -348,8 +347,8 @@ HREF="http://mirrors.hostlogix.net/www.metamath.org/index.html"
 <!--
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://us2.metamath.org:88/index.html"><img
-SRC="_flag-us.png" WIDTH=64 HEIGHT=32 ALT="US" ALIGN=middle BORDER=0></A>
+HREF="http://us2.metamath.org:88/index.html"><IMG SRC="_flag-us.png"
+WIDTH=64 HEIGHT=32 ALT="US" ALIGN=middle BORDER=0></A>
 </TD><TD>
 <A TARGET="_top"
 HREF="http://us2.metamath.org/index.html">us2.metamath.org</A>
@@ -375,16 +374,14 @@ HREF="http://us2.metamath.org:8888/index.html">us2.metamath.org:8888</A>.)
 <!--
 <TABLE CELLSPACING=5><TR><TD>
 <A TARGET="_top"
-HREF="http://de2.metamath.org/index.html"><img
-SRC="_flag-de-vintage.png" WIDTH=64 HEIGHT=32
-  ALT="DE" ALIGN=middle BORDER=0></A>
+HREF="http://de2.metamath.org/index.html"><IMG SRC="_flag-de-vintage.png"
+WIDTH=64 HEIGHT=32 ALT="DE" ALIGN=middle BORDER=0></A>
 -->
 
 <!--
 <A TARGET="_top"
-HREF="http://de2.metamath.org/index.html"><img
-SRC="_flag-de.png" WIDTH=64 HEIGHT=32
-  ALT="DE" ALIGN=middle BORDER=0></A>
+HREF="http://de2.metamath.org/index.html"><IMG SRC="_flag-de.png"
+WIDTH=64 HEIGHT=32 ALT="DE" ALIGN=middle BORDER=0></A>
 </TD><TD>
 
 <A TARGET="_top"
@@ -450,8 +447,7 @@ HREF="http://de2.metamath.org/index.html">de2.metamath.org</A>
 
 <!--
 <TABLE><TR><TD ALIGN=CENTER>
-<img
-SRC="_nm.png"
+<IMG SRC="_nm.png"
 ALIGN=TOP BORDER=0 ALT="Norm">
 </TD></TR><TR><TD ALIGN=CENTER>
 <FONT COLOR="#8B8B8B" SIZE=-1>Norm</FONT>
@@ -460,8 +456,7 @@ ALIGN=TOP BORDER=0 ALT="Norm">
 
 <!--
 <TABLE><TR><TD ALIGN=CENTER>
-<img
-SRC="nm-by-caroline.png" WIDTH=120 HEIGHT=150 ALT="Norm
+<IMG SRC="nm-by-caroline.png" WIDTH=120 HEIGHT=150 ALT="Norm
 by Caroline, age 10" ALIGN=TOP BORDER=0>
 </TD></TR><TR><TD ALIGN=CENTER>
 <FONT COLOR="#8B8B8B" SIZE=-1>Norm</FONT><BR>

--- a/mm_100.html
+++ b/mm_100.html
@@ -8,6 +8,7 @@
 -->
 
 <head>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
 
 <!-- improve mobile display -->
 <META NAME="viewport" CONTENT="width=device-width, initial-scale=1.0">

--- a/mmsolitaire/mms.html
+++ b/mmsolitaire/mms.html
@@ -427,9 +427,9 @@ implies <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>&quot;),
 which means &quot;if something is true, then it is
 true&quot;.  From the 'Axioms:'  (right-hand) menu, select in succession
 ax-1, ax-1, ax-2, ax-mp, and ax-mp.  You will see the logic undergo
-transformations to result in <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG
-SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cpblue.gif'
+transformations to result in <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19
+ALT='P'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cpblue.gif'
 WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'>.  Select 'Proof Information' from
 the left-hand menu to see the details of the proof you built.
@@ -487,17 +487,17 @@ with a different color for each type.  Suppose <IMG SRC='_cpblue.gif'
 WIDTH=12 HEIGHT=19 ALT='P'> and <IMG SRC='_cqblue.gif' WIDTH=12
 HEIGHT=19 ALT='Q'> are wff variables, and <IMG SRC='_x.gif' WIDTH=10
 HEIGHT=19 ALT='x'> and <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'> are
-set variables.  Then <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+set variables.  Then <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19
-ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>, <IMG
-SRC='lnot.gif' WIDTH=10 HEIGHT=19 ALT='-.'> <IMG SRC='_cpblue.gif'
+ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>, <IMG SRC='lnot.gif'
+WIDTH=10 HEIGHT=19 ALT='-.'> <IMG SRC='_cpblue.gif'
 WIDTH=12 HEIGHT=19 ALT='P'>, <IMG SRC='forall.gif' WIDTH=10 HEIGHT=19
-ALT='A.'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>, <IMG SRC='_x.gif'
-WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
-ALT='='> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'>, and <IMG
-SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='in.gif' WIDTH=10
+ALT='A.'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'><IMG SRC='_cpblue.gif'
+WIDTH=12 HEIGHT=19 ALT='P'>, <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19
+ALT='x'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
+ALT='='> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'>, and
+<IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='in.gif' WIDTH=10
 HEIGHT=19 ALT='e.'> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'> are
 wffs and can be substituted for wff variables in an axiom or theorem.
 Set variables can only be substituted with other set variables.
@@ -511,8 +511,8 @@ instead of Roman letters
 to represent wff variables, but the meaning is the same.]
 
 <P>For set theory, we introduce some definitions to make things a little
-more compact.  The defined symbols are:  <MENU> <LI> <IMG
-SRC='leftrightarrow.gif' WIDTH=15 HEIGHT=19 ALT='&lt;-&gt;'> (double
+more compact.  The defined symbols are:  <MENU>
+<LI> <IMG SRC='leftrightarrow.gif' WIDTH=15 HEIGHT=19 ALT='&lt;-&gt;'> (double
 arrow):  logically equivalent to</LI>
 
 <LI> <IMG SRC='vee.gif' WIDTH=11 HEIGHT=19 ALT='\/'> (vee):
@@ -526,8 +526,8 @@ and</LI>
 
 <LI> <IMG SRC='lbrace.gif' WIDTH=6 HEIGHT=19 ALT='{'><IMG SRC='_x.gif'
 WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='vert.gif' WIDTH=3 HEIGHT=19
-ALT='|'> <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG
-SRC='rbrace.gif' WIDTH=6 HEIGHT=19 ALT='}'>:  class abstraction (or
+ALT='|'> <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19
+ALT='P'><IMG SRC='rbrace.gif' WIDTH=6 HEIGHT=19 ALT='}'>:  class abstraction (or
 class builder):  the class of (sets) <IMG SRC='_x.gif' WIDTH=10
 HEIGHT=19 ALT='x'> such that (wff) <IMG SRC='_cpblue.gif' WIDTH=12
 HEIGHT=19 ALT='P'> is true</LI>
@@ -551,48 +551,48 @@ sans-serif U):  union of a class</LI>
 with slash):  empty set</LI> </MENU> Their definitions, which you can
 see on the 'Axiom Information' screen, introduce a new type of variable
 called a &quot;class&quot; shown in purple.  A set <IMG SRC='_x.gif'
-WIDTH=10 HEIGHT=19 ALT='x'> is a class, a class abstraction <IMG
-SRC='lbrace.gif' WIDTH=6 HEIGHT=19 ALT='{'><IMG SRC='_x.gif' WIDTH=10
-HEIGHT=19 ALT='x'> <IMG SRC='vert.gif' WIDTH=3 HEIGHT=19 ALT='|'> <IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rbrace.gif'
-WIDTH=6 HEIGHT=19 ALT='}'> is a class, and the empty set <IMG
-SRC='varnothing.gif' WIDTH=11 HEIGHT=19 ALT='(/)'> is a class.  If <IMG
-SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> and <IMG SRC='_cb.gif'
+WIDTH=10 HEIGHT=19 ALT='x'> is a class, a class abstraction
+<IMG SRC='lbrace.gif' WIDTH=6 HEIGHT=19 ALT='{'><IMG SRC='_x.gif' WIDTH=10
+HEIGHT=19 ALT='x'> <IMG SRC='vert.gif' WIDTH=3 HEIGHT=19 ALT='|'>
+<IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rbrace.gif'
+WIDTH=6 HEIGHT=19 ALT='}'> is a class, and the empty set
+<IMGRC='varnothing.gif' WIDTH=11 HEIGHT=19 ALT='(/)'> is a class.  If
+<IMGRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> and <IMG SRC='_cb.gif'
 WIDTH=12 HEIGHT=19 ALT='B'> are variables representing classes, then
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ca.gif' WIDTH=11
-HEIGHT=19 ALT='A'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='u.'> <IMG
-SRC='_cb.gif' WIDTH=12 HEIGHT=19 ALT='B'><IMG SRC='rp.gif' WIDTH=5
-HEIGHT=19 ALT=')'>, <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> <IMG SRC='cap.gif' WIDTH=10
-HEIGHT=19 ALT='i^i'> <IMG SRC='_cb.gif' WIDTH=12 HEIGHT=19 ALT='B'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>, <IMG SRC='bigcup.gif' WIDTH=13
+HEIGHT=19 ALT='A'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='u.'>
+<IMG SRC='_cb.gif' WIDTH=12 HEIGHT=19 ALT='B'><IMG SRC='rp.gif' WIDTH=5
+HEIGHT=19 ALT=')'>, <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> <IMG SRC='cap.gif' WIDTH=10
+HEIGHT=19 ALT='i^i'> <IMG SRC='_cb.gif' WIDTH=12 HEIGHT=19
+ALT='B'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>, <IMG SRC='bigcup.gif' WIDTH=13
 HEIGHT=19 ALT='U.'><IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'>, and
 <IMG SRC='bigcap.gif' WIDTH=13 HEIGHT=19 ALT='|^|'><IMG SRC='_ca.gif'
 WIDTH=11 HEIGHT=19 ALT='A'> are classes.  Any expression qualifying as a
 class may be substituted for a class variable.
 
 <P>With our new symbols, we also extend the definition of a wff.  If
-<IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> is a set, <IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> and <IMG SRC='_cqblue.gif'
+<IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> is a set,
+<IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> and <IMG SRC='_cqblue.gif'
 WIDTH=12 HEIGHT=19 ALT='Q'> are wffs, and <IMG SRC='_ca.gif' WIDTH=11
 HEIGHT=19 ALT='A'> and <IMG SRC='_cb.gif' WIDTH=12 HEIGHT=19 ALT='B'>
-are classes, then <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG
-SRC='leftrightarrow.gif' WIDTH=15 HEIGHT=19 ALT='&lt;-&gt;'> <IMG
-SRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif' WIDTH=5
-HEIGHT=19 ALT=')'>, <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='vee.gif'
+are classes, then <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>
+<IMGRC='leftrightarrow.gif' WIDTH=15 HEIGHT=19 ALT='&lt;-&gt;'>
+<IMGRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif' WIDTH=5
+HEIGHT=19 ALT=')'>, <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='vee.gif'
 WIDTH=11 HEIGHT=19 ALT='\/'> <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19
 ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>, <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19
-ALT='P'> <IMG SRC='wedge.gif' WIDTH=11 HEIGHT=19 ALT='/\'> <IMG
-SRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif' WIDTH=5
+ALT='P'> <IMG SRC='wedge.gif' WIDTH=11 HEIGHT=19 ALT='/\'>
+<IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'>, <IMG SRC='exists.gif' WIDTH=9 HEIGHT=19
-ALT='E.'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>, <IMG SRC='_ca.gif'
+ALT='E.'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19
+ALT='x'><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>, <IMG SRC='_ca.gif'
 WIDTH=11 HEIGHT=19 ALT='A'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
-ALT='='> <IMG SRC='_cb.gif' WIDTH=12 HEIGHT=19 ALT='B'>, <IMG
-SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> <IMG SRC='in.gif' WIDTH=10
+ALT='='> <IMG SRC='_cb.gif' WIDTH=12 HEIGHT=19 ALT='B'>,
+<IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> <IMG SRC='in.gif' WIDTH=10
 HEIGHT=19 ALT='e.'> <IMG SRC='_cb.gif' WIDTH=12 HEIGHT=19 ALT='B'>, and
 <IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> <IMG SRC='subseteq.gif'
 WIDTH=12 HEIGHT=19 ALT='(_'> <IMG SRC='_cb.gif' WIDTH=12 HEIGHT=19
@@ -605,39 +605,39 @@ expressions qualifying as classes can contain wff variables.  All axioms
 
 <P>Class variables are not part of the primitive language.  A class
 variable <IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> can be
-eliminated from any theorem in which it occurs by replacing it with <IMG
-SRC='lbrace.gif' WIDTH=6 HEIGHT=19 ALT='{'><IMG SRC='_x.gif' WIDTH=10
-HEIGHT=19 ALT='x'> <IMG SRC='vert.gif' WIDTH=3 HEIGHT=19 ALT='|'> <IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rbrace.gif'
+eliminated from any theorem in which it occurs by replacing it with
+<IMGRC='lbrace.gif' WIDTH=6 HEIGHT=19 ALT='{'><IMG SRC='_x.gif' WIDTH=10
+HEIGHT=19 ALT='x'> <IMG SRC='vert.gif' WIDTH=3 HEIGHT=19 ALT='|'>
+<IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rbrace.gif'
 WIDTH=6 HEIGHT=19 ALT='}'> where <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19
 ALT='x'> and <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> are new
 set and wff variables not otherwise occurring in the theorem.  Here is a
 sketch of how we transform <IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19
-ALT='A'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'>, for example, to a primitive
+ALT='A'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'>, for example, to a primitive
 wff:  <IMG SRC='lbrace.gif' WIDTH=6 HEIGHT=19 ALT='{'><IMG SRC='_x.gif'
 WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='vert.gif' WIDTH=3 HEIGHT=19
-ALT='|'> <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG
-SRC='rbrace.gif' WIDTH=6 HEIGHT=19 ALT='}'> <IMG SRC='eq.gif' WIDTH=12
-HEIGHT=19 ALT='='> <IMG SRC='lbrace.gif' WIDTH=6 HEIGHT=19 ALT='{'><IMG
-SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='vert.gif' WIDTH=3
+ALT='|'> <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19
+ALT='P'><IMG SRC='rbrace.gif' WIDTH=6 HEIGHT=19 ALT='}'> <IMG SRC='eq.gif' WIDTH=12
+HEIGHT=19 ALT='='> <IMG SRC='lbrace.gif' WIDTH=6 HEIGHT=19
+ALT='{'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='vert.gif' WIDTH=3
 HEIGHT=19 ALT='|'> <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19
-ALT='P'><IMG SRC='rbrace.gif' WIDTH=6 HEIGHT=19 ALT='}'> becomes <IMG
-SRC='forall.gif' WIDTH=10 HEIGHT=19 ALT='A.'><IMG SRC='_x.gif' WIDTH=10
-HEIGHT=19 ALT='x'><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG
-SRC='leftrightarrow.gif' WIDTH=15 HEIGHT=19 ALT='&lt;-&gt;'> <IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rp.gif' WIDTH=5
+ALT='P'><IMG SRC='rbrace.gif' WIDTH=6 HEIGHT=19 ALT='}'> becomes
+<IMG SRC='forall.gif' WIDTH=10 HEIGHT=19 ALT='A.'><IMG SRC='_x.gif' WIDTH=10
+HEIGHT=19 ALT='x'><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>
+<IMGRC='leftrightarrow.gif' WIDTH=15 HEIGHT=19 ALT='&lt;-&gt;'>
+<IMGRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> which finally becomes <IMG SRC='forall.gif' WIDTH=10
-HEIGHT=19 ALT='A.'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'><IMG
-SRC='lnot.gif' WIDTH=10 HEIGHT=19 ALT='-.'> <IMG SRC='lp.gif' WIDTH=5
-HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+HEIGHT=19 ALT='A.'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19
+ALT='x'><IMG SRC='lnot.gif' WIDTH=10 HEIGHT=19 ALT='-.'> <IMG SRC='lp.gif' WIDTH=5
+HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19
 ALT='P'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='to.gif'
 WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='lnot.gif' WIDTH=10 HEIGHT=19
-ALT='-.'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+ALT='-.'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19
 ALT='P'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'>.
@@ -646,11 +646,11 @@ WIDTH=5 HEIGHT=19 ALT=')'>.
 with other set variables.  We can substitute set variable <IMG SRC='_x.gif'
 WIDTH=10 HEIGHT=19 ALT='x'> for class
 variable <IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> in the
-theorem <IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> <IMG
-SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_ca.gif' WIDTH=11
+theorem <IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'>
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_ca.gif' WIDTH=11
 HEIGHT=19 ALT='A'> to conclude <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19
-ALT='x'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'>, but we can't conclude
+ALT='x'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'>, but we can't conclude
 <IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19
 ALT='A'> from <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'>
@@ -681,15 +681,15 @@ hypotheses and is usually called an "inference rule" rather than an
 axiom; "mp" stands for "modus ponens".
 
 <P> Modus ponens has two hypotheses, <IMG SRC='_cpblue.gif' WIDTH=12
-HEIGHT=19 ALT='P'> and <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+HEIGHT=19 ALT='P'> and <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19
-ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> (read &quot;<IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> implies <IMG
-SRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'>&quot;).  It asserts that
+ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> (read
+&quot;<IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> implies
+<IMGRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'>&quot;).  It asserts that
 if we have proved two assertions, <IMG SRC='_cpblue.gif' WIDTH=12
-HEIGHT=19 ALT='P'> and <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+HEIGHT=19 ALT='P'> and <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19
 ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>, we can infer a
 third assertion, namely <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19
@@ -708,11 +708,11 @@ This is called &quot;unification&quot;.  After unification, the unified
 hypotheses are removed from the stack, and the axiom's assertion, with
 substitutions made to it, is added to the stack.  Note that the top of
 the stack must be matchable to the <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
-ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG
-SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cqblue.gif'
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>
+<IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cqblue.gif'
 WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-hypothesis of ax-mp, and the one under it must be matchable to <IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>.
+hypothesis of ax-mp, and the one under it must be matchable to
+<IMGRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>.
 
 <P>If you click on ax-1, ax-2, or ax-3, there is no unification because
 they have no hypotheses.  Instead, they are just added to the stack.
@@ -761,8 +761,8 @@ ax-mp ax-gen ax-ext ax-mp
 <P>There, your first proof using an axiom of set theory!
 
 <P>To prove the more general <IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19
-ALT='A'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> for classes, click on 'Select
+ALT='A'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> for classes, click on 'Select
 Logic Family' then 'ZFC Set Theory + Definitions'.  Then click on:
 
 <P>ax-1 ax-1 ax-2 ax-mp ax-mp ax-1 ax-1 ax-2 ax-mp ax-mp df-bi3 ax-mp
@@ -784,17 +784,17 @@ again.  Rather than prove it anew each time, you can add it as an
 additional axiom.
 
 <P> For example, a very useful rule is the syllogism inference.  It has
-hypotheses <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+hypotheses <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19
-ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> and <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cqblue.gif' WIDTH=12
+ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> and
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cqblue.gif' WIDTH=12
 HEIGHT=19 ALT='Q'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'>
 <IMG SRC='_crblue.gif' WIDTH=12 HEIGHT=19 ALT='R'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> from which it asserts <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19
-ALT='P'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG
-SRC='_crblue.gif' WIDTH=12 HEIGHT=19 ALT='R'><IMG SRC='rp.gif' WIDTH=5
+ALT='P'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'>
+<IMG SRC='_crblue.gif' WIDTH=12 HEIGHT=19 ALT='R'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'>.  Select 'Add Hypothesis' twice.  Then select Axioms
 $hyp1, $hyp2, ax-1, ax-mp, ax-2, ax-mp, ax-mp.  Click on 'Save as
 Axiom'.  You will see it stored as 'user-1' on the 'Axiom Information'
@@ -835,76 +835,76 @@ started.  To abbreviate the proofs, I've used 1, 2, 3, and m in place of
 ax-1, ax-2, ax-3, and ax-mp.  If you find a clever proof, send it to me
 and maybe I'll post it here, with your name attached to it, of course!
 
-<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12
+<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12
 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'>
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cqblue.gif'
 WIDTH=12 HEIGHT=19 ALT='Q'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19
-ALT='-&gt;'> <IMG SRC='_crblue.gif' WIDTH=12 HEIGHT=19 ALT='R'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALT='-&gt;'> <IMG SRC='_crblue.gif' WIDTH=12 HEIGHT=19
+ALT='R'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'>
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cqblue.gif'
 WIDTH=12 HEIGHT=19 ALT='Q'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19
-ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_crblue.gif' WIDTH=12 HEIGHT=19
 ALT='R'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 &nbsp;Proof:  (19 steps) 211m2mm11m22mm1m2mm
 
-<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cqblue.gif' WIDTH=12
+<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cqblue.gif' WIDTH=12
 HEIGHT=19 ALT='Q'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'>
 <IMG SRC='_crblue.gif' WIDTH=12 HEIGHT=19 ALT='R'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19
-ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12
+ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12
 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'>
 <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19
-ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_crblue.gif' WIDTH=12 HEIGHT=19
 ALT='R'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 &nbsp;Proof:  (7 steps) 121m2mm
 
-<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12
+<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12
 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'>
 <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19
-ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cqblue.gif' WIDTH=12
+ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_cqblue.gif' WIDTH=12
 HEIGHT=19 ALT='Q'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'>
 <IMG SRC='_crblue.gif' WIDTH=12 HEIGHT=19 ALT='R'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19
-ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_crblue.gif' WIDTH=12 HEIGHT=19
 ALT='R'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 &nbsp;Proof:  (15 steps) 1121m2mm2m1m2mm
 
-<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='lnot.gif' WIDTH=10 HEIGHT=19 ALT='-.'>
 <IMG SRC='lnot.gif' WIDTH=10 HEIGHT=19 ALT='-.'> <IMG SRC='_cpblue.gif'
 WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 &nbsp;Proof:  (19 steps) 1131m2mm31m2mm2mm3m
 
-<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lnot.gif' WIDTH=10 HEIGHT=19 ALT='-.'> <IMG SRC='lnot.gif' WIDTH=10
+<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lnot.gif' WIDTH=10 HEIGHT=19 ALT='-.'> <IMG SRC='lnot.gif' WIDTH=10
 HEIGHT=19 ALT='-.'> <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>
 <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cpblue.gif'
 WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 &nbsp;Proof:  (17 steps) 1131m2mm31m2mm2mm
 
-<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lnot.gif' WIDTH=10 HEIGHT=19 ALT='-.'> <IMG SRC='_cpblue.gif'
+<P>Theorem:  <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lnot.gif' WIDTH=10 HEIGHT=19 ALT='-.'> <IMG SRC='_cpblue.gif'
 WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19
-ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
+ALT='-&gt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19
 ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> &nbsp;Proof:  (7 steps) 131m2mm
@@ -924,8 +924,8 @@ WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'>
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_crblue.gif'
 WIDTH=12 HEIGHT=19 ALT='R'> <IMG SRC='to.gif' WIDTH=15 HEIGHT=19
 ALT='-&gt;'> <IMG SRC='_cqblue.gif'
-WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 &nbsp;Proof:  11m2m (contributed by Andrew Salmon, 8-Jun-2011)
 -->
 
@@ -1039,8 +1039,8 @@ wffs and individual variables, along with zero or more restrictions of
 the forms &quot;where <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> and
 <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'> are distinct individual
 variables&quot; and &quot;where <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19
-ALT='x'> is an individual variable not occurring in wff <IMG
-SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>&quot;.  These terms are
+ALT='x'> is an individual variable not occurring in wff
+<IMGRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>&quot;.  These terms are
 explained in more detail in Remark 9.6 of this <A
 HREF="../downloads/finiteaxiom.pdf">article</A> (PDF file).
 
@@ -1074,20 +1074,20 @@ we may safely infer <IMG SRC='exists.gif' WIDTH=9 HEIGHT=19
 ALT='E.'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'><IMG SRC='_x.gif'
 WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
 ALT='='> <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> since we can
-prove the former without variable restrictions, but from <IMG
-SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='in.gif' WIDTH=10
-HEIGHT=19 ALT='e.'> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'> <IMG
-SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='forall.gif'
+prove the former without variable restrictions, but from
+<IMGRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='in.gif' WIDTH=10
+HEIGHT=19 ALT='e.'> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'>
+<IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='forall.gif'
 WIDTH=10 HEIGHT=19 ALT='A.'><IMG SRC='_z.gif' WIDTH=9 HEIGHT=19
 ALT='z'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='in.gif'
 WIDTH=10 HEIGHT=19 ALT='e.'> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19
 ALT='y'> (which will have the restrictions <IMG SRC='_z.gif' WIDTH=9
 HEIGHT=19 ALT='z'> distinct from <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19
 ALT='x'> and <IMG SRC='_z.gif' WIDTH=9 HEIGHT=19 ALT='z'> distinct from
-<IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'>) we may not infer <IMG
-SRC='_z.gif' WIDTH=9 HEIGHT=19 ALT='z'> <IMG SRC='in.gif' WIDTH=10
-HEIGHT=19 ALT='e.'> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'> <IMG
-SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='forall.gif'
+<IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'>) we may not infer
+<IMG SRC='_z.gif' WIDTH=9 HEIGHT=19 ALT='z'> <IMG SRC='in.gif' WIDTH=10
+HEIGHT=19 ALT='e.'> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'>
+<IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='forall.gif'
 WIDTH=10 HEIGHT=19 ALT='A.'><IMG SRC='_z.gif' WIDTH=9 HEIGHT=19
 ALT='z'><IMG SRC='_z.gif' WIDTH=9 HEIGHT=19 ALT='z'> <IMG SRC='in.gif'
 WIDTH=10 HEIGHT=19 ALT='e.'> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19

--- a/mmsolitaire/mms.html
+++ b/mmsolitaire/mms.html
@@ -556,8 +556,8 @@ WIDTH=10 HEIGHT=19 ALT='x'> is a class, a class abstraction
 HEIGHT=19 ALT='x'> <IMG SRC='vert.gif' WIDTH=3 HEIGHT=19 ALT='|'>
 <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rbrace.gif'
 WIDTH=6 HEIGHT=19 ALT='}'> is a class, and the empty set
-<IMGRC='varnothing.gif' WIDTH=11 HEIGHT=19 ALT='(/)'> is a class.  If
-<IMGRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> and <IMG SRC='_cb.gif'
+<IMG SRC='varnothing.gif' WIDTH=11 HEIGHT=19 ALT='(/)'> is a class.  If
+<IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> and <IMG SRC='_cb.gif'
 WIDTH=12 HEIGHT=19 ALT='B'> are variables representing classes, then
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ca.gif' WIDTH=11
 HEIGHT=19 ALT='A'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='u.'>
@@ -578,8 +578,8 @@ WIDTH=12 HEIGHT=19 ALT='Q'> are wffs, and <IMG SRC='_ca.gif' WIDTH=11
 HEIGHT=19 ALT='A'> and <IMG SRC='_cb.gif' WIDTH=12 HEIGHT=19 ALT='B'>
 are classes, then <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>
-<IMGRC='leftrightarrow.gif' WIDTH=15 HEIGHT=19 ALT='&lt;-&gt;'>
-<IMGRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif' WIDTH=5
+<IMG SRC='leftrightarrow.gif' WIDTH=15 HEIGHT=19 ALT='&lt;-&gt;'>
+<IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'>, <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='vee.gif'
 WIDTH=11 HEIGHT=19 ALT='\/'> <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19
@@ -606,7 +606,7 @@ expressions qualifying as classes can contain wff variables.  All axioms
 <P>Class variables are not part of the primitive language.  A class
 variable <IMG SRC='_ca.gif' WIDTH=11 HEIGHT=19 ALT='A'> can be
 eliminated from any theorem in which it occurs by replacing it with
-<IMGRC='lbrace.gif' WIDTH=6 HEIGHT=19 ALT='{'><IMG SRC='_x.gif' WIDTH=10
+<IMG SRC='lbrace.gif' WIDTH=6 HEIGHT=19 ALT='{'><IMG SRC='_x.gif' WIDTH=10
 HEIGHT=19 ALT='x'> <IMG SRC='vert.gif' WIDTH=3 HEIGHT=19 ALT='|'>
 <IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rbrace.gif'
 WIDTH=6 HEIGHT=19 ALT='}'> where <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19
@@ -626,8 +626,8 @@ ALT='P'><IMG SRC='rbrace.gif' WIDTH=6 HEIGHT=19 ALT='}'> becomes
 <IMG SRC='forall.gif' WIDTH=10 HEIGHT=19 ALT='A.'><IMG SRC='_x.gif' WIDTH=10
 HEIGHT=19 ALT='x'><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>
-<IMGRC='leftrightarrow.gif' WIDTH=15 HEIGHT=19 ALT='&lt;-&gt;'>
-<IMGRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rp.gif' WIDTH=5
+<IMG SRC='leftrightarrow.gif' WIDTH=15 HEIGHT=19 ALT='&lt;-&gt;'>
+<IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> which finally becomes <IMG SRC='forall.gif' WIDTH=10
 HEIGHT=19 ALT='A.'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19
 ALT='x'><IMG SRC='lnot.gif' WIDTH=10 HEIGHT=19 ALT='-.'> <IMG SRC='lp.gif' WIDTH=5
@@ -686,7 +686,7 @@ ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WID
 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19
 ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> (read
 &quot;<IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> implies
-<IMGRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'>&quot;).  It asserts that
+<IMG SRC='_cqblue.gif' WIDTH=12 HEIGHT=19 ALT='Q'>&quot;).  It asserts that
 if we have proved two assertions, <IMG SRC='_cpblue.gif' WIDTH=12
 HEIGHT=19 ALT='P'> and <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'> <IMG SRC='to.gif' WIDTH=15
@@ -712,7 +712,7 @@ ALT='('><IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>
 <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='_cqblue.gif'
 WIDTH=12 HEIGHT=19 ALT='Q'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 hypothesis of ax-mp, and the one under it must be matchable to
-<IMGRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>.
+<IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>.
 
 <P>If you click on ax-1, ax-2, or ax-3, there is no unification because
 they have no hypotheses.  Instead, they are just added to the stack.
@@ -1040,7 +1040,7 @@ the forms &quot;where <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> and
 <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'> are distinct individual
 variables&quot; and &quot;where <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19
 ALT='x'> is an individual variable not occurring in wff
-<IMGRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>&quot;.  These terms are
+<IMG SRC='_cpblue.gif' WIDTH=12 HEIGHT=19 ALT='P'>&quot;.  These terms are
 explained in more detail in Remark 9.6 of this <A
 HREF="../downloads/finiteaxiom.pdf">article</A> (PDF file).
 
@@ -1075,7 +1075,7 @@ ALT='E.'><IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'><IMG SRC='_x.gif'
 WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
 ALT='='> <IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> since we can
 prove the former without variable restrictions, but from
-<IMGRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='in.gif' WIDTH=10
+<IMG SRC='_x.gif' WIDTH=10 HEIGHT=19 ALT='x'> <IMG SRC='in.gif' WIDTH=10
 HEIGHT=19 ALT='e.'> <IMG SRC='_y.gif' WIDTH=9 HEIGHT=19 ALT='y'>
 <IMG SRC='to.gif' WIDTH=15 HEIGHT=19 ALT='-&gt;'> <IMG SRC='forall.gif'
 WIDTH=10 HEIGHT=19 ALT='A.'><IMG SRC='_z.gif' WIDTH=9 HEIGHT=19

--- a/mpegif/mmmusic.html
+++ b/mpegif/mmmusic.html
@@ -175,10 +175,10 @@ for every proof step.  Sometimes, syncopation has only a small effect,
 as in the case of the <B>Second Peano Postulate</B> <A
 HREF="peano2.mid"><IMG SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10
 HEIGHT=15><FONT SIZE=-2>0:16</FONT></A>.  Other times the effect is
-significant; compare the <A HREF="abstri.mid">syncopated<IMG
-SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
-SIZE=-2>1:49</FONT></A> and <A HREF="abstri-ns.mid">non-syncopated<IMG
-SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
+significant; compare the <A HREF="abstri.mid">syncopated<IMG SRC="_note.gif"
+ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
+SIZE=-2>1:49</FONT></A> and <A HREF="abstri-ns.mid">non-syncopated<IMG SRC="_note.gif"
+ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
 SIZE=-2>1:49</FONT></A> versions of the <B>Triangle Inequality</B>
 <A NAME="L46-7"></A>
 (and also <A HREF="#modify">another version</A>).
@@ -195,8 +195,8 @@ ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
 SIZE=-2>3:51</FONT></A>, where a crescendo slowly builds up starting at
 around 2:20 minutes, reaching a dramatic climax at 3:11 minutes and then
 suddenly cascading down to the main theme.  Another frenzied, climactic
-piece is <B>Zermelo's Well-Ordering Theorem</B> <A HREF="weth.mid"><IMG
-SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
+piece is <B>Zermelo's Well-Ordering Theorem</B> <A HREF="weth.mid"><IMG SRC="_note.gif"
+ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
 SIZE=-2>0:50</FONT></A>.  The <B>Schr&ouml;der-Bernstein Theorem</B> <A
 HREF="sbth.mid"><IMG SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10
 HEIGHT=15><FONT SIZE=-2>1:47</FONT></A> (I like this one) changes its
@@ -244,8 +244,8 @@ construction of the formulas used in those steps.
 <P><TABLE BORDER=0><TR><TD VALIGN=TOP WIDTH="50%">
 <MENU>
 
-<LI> <A HREF="idALT.html">Law of identity</A> <A HREF="id1.mid"><IMG
-SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT SIZE=-2>0:05</FONT></A> </LI>
+<LI> <A HREF="idALT.html">Law of identity</A> <A HREF="id1.mid"><IMG SRC="_note.gif"
+ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT SIZE=-2>0:05</FONT></A> </LI>
 
 <LI>
 <A HREF="peirce.html">Peirce's axiom</A>
@@ -839,8 +839,8 @@ Algorithm</FONT></B>&nbsp;&nbsp;&nbsp;
 
 
 I'll use as an example the simple theorem <TT>idALT</TT> which is the <A
-HREF="idALT.html">Law of Identity</A> <A HREF="id1.mid"><IMG
-SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
+HREF="idALT.html">Law of Identity</A> <A HREF="id1.mid"><IMG SRC="_note.gif"
+ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
 SIZE=-2>0:05</FONT></A>.  The database file <TT>set.mm</TT> stores the
 proof in a compressed format to save space, so first we must store it
 internally in uncompressed format, otherwise when we view the proof
@@ -927,9 +927,8 @@ above is<BR>
 where the 53 is the first sustained note.
 
 <P>Now, listen carefully to the <A
-HREF="idALT.html">Law of Identity</A> <A HREF="id1.mid"><IMG
-SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
-SIZE=-2>0:05</FONT></A>, and you
+HREF="idALT.html">Law of Identity</A> <A HREF="id1.mid"><IMG SRC="_note.gif"
+ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT SIZE=-2>0:05</FONT></A>, and you
 will hear that the first 12 notes and pauses match exactly the above
 sequence.
 
@@ -961,8 +960,8 @@ http://eartha.mills.edu:8000/guest/archives/ba-newmus/log0403/msg00136.html
 (By the way, the "b", "w", and "i" parameters that are already available
 may appeal to more conventional musical tastes.  An example is the
 <B>Triangle Inequality</B>
-<A HREF="abstri-fsbi.mid"><IMG
-SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
+<A HREF="abstri-fsbi.mid"><IMG SRC="_note.gif"
+ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
 SIZE=-2>1:49</FONT></A> played with the black keys, using the parameter
 string "fsbi".  To me it lacks some of the vaguely disturbing eeriness
 of the other versions, and there is a certain gentle pleasantness to it.
@@ -1010,8 +1009,8 @@ George Sherwood
 (<A
 HREF="https://web.archive.org/web/20011205184456/http://home.att.net/~darkblues/">old
 home page</A>) has combined a few of the proofs on this page into an
-original arrangement called <A HREF="abstricombo.mid">Abstricombo<IMG
-SRC="_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
+original arrangement called <A HREF="abstricombo.mid">Abstricombo<IMG SRC="_note.gif"
+ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
 SIZE=-2>5:13</FONT></A> (Copyright &copy; 2000 DarkBlues).  He writes:
 
 <BLOCKQUOTE><I>

--- a/other.html
+++ b/other.html
@@ -164,7 +164,7 @@ Google Groups discussion</A> [retrieved 4-Aug-2016].</LI>
        (28-Apr-2015)</LI>
 
   <LI> <A HREF="downloads/ihp2014mm.pdf">Overview of Metamath</A>
-         presentation by Norm Megill at Institut Henri Poincar� (2014)</LI>
+         presentation by Norm Megill at Institut Henri Poincaré (2014)</LI>
 
   <LI> <A HREF="award2003.html">Open problems and miscellany</A> discussed
     at 2003, 2004, and 2005 Argonne workshops</LI>
@@ -236,7 +236,7 @@ HREF="https://www.youtube.com/watch?v=XC1g8FmFcUU">"Metamath Proof
  Gource through 2019-10-04"</A> (6-Oct-2019) [retrieved 20-Jan-2020].</LI>
       <LI><A
 HREF="https://youtu.be/3R27Qx69jHc">"Formalizing Geometric
-Proof Schwabh�user 4.6 in the Metamath Proof Explorer"</A>
+Proof Schwabhäuser 4.6 in the Metamath Proof Explorer"</A>
 (19-Jul-2020) [retrieved 19-Jul-2020].</LI>
       </UL>
   </LI>
@@ -449,7 +449,7 @@ O'Rear).  </LI>
 <LI><A NAME="metamath-ada"></A><A
 HREF="https://github.com/david-a-wheeler/metamath-ada">metamath-ada</A>
 (16-Jul-2017) - a simple Metamath proof checker [retrieved 15-Aug-2016]
-(written in Ada by Tony H�ger).  It should probably be considered to be
+(written in Ada by Tony Häger).  It should probably be considered to be
 under development; see this this <A
 HREF="https://groups.google.com/d/msg/metamath/SCrP3O56SVQ/XztfHfRRBgAJ">Google
 Group</A> message for its limitations.  A zip download is also attached
@@ -740,7 +740,7 @@ HREF="https://ihp2014.pps.univ-paris-diderot.fr/doku.php?id=workshop_1">
 "Formalization of mathematics in proof assistants"</A>
 [retrieved 12-Jul-2015] workshop at the
 <A HREF="http://www.ihp.fr/en/ceb/trimester/proofs/workshop1">Institut
-Henri Poincar�</A> [retrieved 12-Jul-2015]
+Henri Poincaré</A> [retrieved 12-Jul-2015]
 in Paris.  The slides for this talk are <A
 HREF="downloads/ihp2014mm.pdf">here</A>.
 

--- a/other.html
+++ b/other.html
@@ -6,7 +6,7 @@
 <!-- improve mobile display -->
 <META NAME="viewport" CONTENT="width=device-width, initial-scale=1.0">
 
-<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
 <TITLE>Other Metamath-Related Topics</TITLE>
 <LINK REL="shortcut icon" HREF="favicon.ico" TYPE="image/x-icon">
 

--- a/other.html
+++ b/other.html
@@ -164,7 +164,7 @@ Google Groups discussion</A> [retrieved 4-Aug-2016].</LI>
        (28-Apr-2015)</LI>
 
   <LI> <A HREF="downloads/ihp2014mm.pdf">Overview of Metamath</A>
-         presentation by Norm Megill at Institut Henri Poincaré (2014)</LI>
+         presentation by Norm Megill at Institut Henri Poincarï¿½ (2014)</LI>
 
   <LI> <A HREF="award2003.html">Open problems and miscellany</A> discussed
     at 2003, 2004, and 2005 Argonne workshops</LI>
@@ -236,7 +236,7 @@ HREF="https://www.youtube.com/watch?v=XC1g8FmFcUU">"Metamath Proof
  Gource through 2019-10-04"</A> (6-Oct-2019) [retrieved 20-Jan-2020].</LI>
       <LI><A
 HREF="https://youtu.be/3R27Qx69jHc">"Formalizing Geometric
-Proof Schwabhäuser 4.6 in the Metamath Proof Explorer"</A>
+Proof Schwabhï¿½user 4.6 in the Metamath Proof Explorer"</A>
 (19-Jul-2020) [retrieved 19-Jul-2020].</LI>
       </UL>
   </LI>
@@ -449,7 +449,7 @@ O'Rear).  </LI>
 <LI><A NAME="metamath-ada"></A><A
 HREF="https://github.com/david-a-wheeler/metamath-ada">metamath-ada</A>
 (16-Jul-2017) - a simple Metamath proof checker [retrieved 15-Aug-2016]
-(written in Ada by Tony Häger).  It should probably be considered to be
+(written in Ada by Tony Hï¿½ger).  It should probably be considered to be
 under development; see this this <A
 HREF="https://groups.google.com/d/msg/metamath/SCrP3O56SVQ/XztfHfRRBgAJ">Google
 Group</A> message for its limitations.  A zip download is also attached
@@ -609,7 +609,7 @@ HREF="https://web.archive.org/web/20131219002242/http://wiki.planetmath.org/cgi-
 >Bourbaki proof checker</A> [retrieved 3-Aug-2016]. </LI>
 
 <LI>Raph Levien has developed a related language called <A
-HREF="http://ghilbert-app.appspot.com">Ghilbert</A> 
+HREF="http://ghilbert-app.appspot.com">Ghilbert</A>
 <!-- retrieved 4-Aug-2016 -->
 that strives to improve upon Metamath by guaranteeing the soundness of
 definitions and providing features useful for collaborative work.
@@ -740,7 +740,7 @@ HREF="https://ihp2014.pps.univ-paris-diderot.fr/doku.php?id=workshop_1">
 "Formalization of mathematics in proof assistants"</A>
 [retrieved 12-Jul-2015] workshop at the
 <A HREF="http://www.ihp.fr/en/ceb/trimester/proofs/workshop1">Institut
-Henri Poincaré</A> [retrieved 12-Jul-2015]
+Henri Poincarï¿½</A> [retrieved 12-Jul-2015]
 in Paris.  The slides for this talk are <A
 HREF="downloads/ihp2014mm.pdf">here</A>.
 
@@ -904,14 +904,14 @@ for fun.  You can listen
 to what mathematical proofs "sound" like!
 
 <!--
-<A HREF="mpeuni/peano2.mid"><IMG
-SRC="mpeuni/_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
+<A HREF="mpeuni/peano2.mid"><IMG SRC="mpeuni/_note.gif"
+ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
 SIZE=-2>0:16</FONT></A>
 -->
 
 <!--
-<A HREF="mpeuni/sqrth-fshbi.mid"><IMG
-SRC="mpeuni/_note.gif" ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
+<A HREF="mpeuni/sqrth-fshbi.mid"><IMG SRC="mpeuni/_note.gif"
+ALT="MIDI file" BORDER=0 WIDTH=10 HEIGHT=15><FONT
 SIZE=-2>0:41</FONT></A>
 -->
 

--- a/qlegif/mmql.html
+++ b/qlegif/mmql.html
@@ -267,20 +267,16 @@ ALIGN=TOP> symbol is a traditional one used in this field.)
 In the literature, you will often see the symbols
 <IMG SRC='perp.gif' WIDTH=11 HEIGHT=19 ALT='_|_'> (as
 a superscript) or ' (prime) as postfix operators for orthocomplementation instead of
-our prefix operation <IMG
-SRC='shortminus.gif' WIDTH=8 HEIGHT=19 ALT='-'>.
+our prefix operation <IMG SRC='shortminus.gif' WIDTH=8 HEIGHT=19 ALT='-'>.
 -->
 
 Formally, an ortholattice or an orthomodular lattice is an algebra
-<IMG
-SRC='langle.gif' WIDTH=4 HEIGHT=19 ALT='&lt;.'><I>A</I>,
+<IMG SRC='langle.gif' WIDTH=4 HEIGHT=19 ALT='&lt;.'><I>A</I>,
 <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19
-ALT='v'>, <IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'><IMG
-SRC='rangle.gif' WIDTH=4 HEIGHT=19 ALT='&gt;.'> where <I>A</I> is
+ALT='v'>, <IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'><IMG SRC='rangle.gif'
+WIDTH=4 HEIGHT=19 ALT='&gt;.'> where <I>A</I> is
 the base set, <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19
-ALT='v'> is a binary operation, and <IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'> is
+ALT='v'> is a binary operation, and <IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'> is
 a unary operation, obeying the axioms below for an ortholattice
 or orthomodular lattice respectively.
 
@@ -307,131 +303,131 @@ hypotheses and conclusion.
 <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
 <CAPTION><B>Axioms for an Ortholattice</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-a1.html">ax-a1</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-a1.html">ax-a1</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19
 ALT='_|_'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-a2.html">ax-a2</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-a2.html">ax-a2</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-a3.html">ax-a3</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-a3.html">ax-a3</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif'
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif'
 WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif' WIDTH=7
 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+ALIGN=TOP> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-a4.html">ax-a4</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-a4.html">ax-a4</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif' WIDTH=9
 HEIGHT=19 ALT='_|_'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
 ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-a5.html">ax-a5</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-a5.html">ax-a5</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_ba.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-r1.html">ax-r1</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-r1.html">ax-r1</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
-WIDTH=15 HEIGHT=19 ALT='=&gt;'>&nbsp;&nbsp;&nbsp; <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='eq.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'>&nbsp;&nbsp;&nbsp; <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-r2.html">ax-r2</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-r2.html">ax-r2</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
-WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='eq.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_bc.gif' WIDTH=7
 HEIGHT=19 ALT='c'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
-WIDTH=15 HEIGHT=19 ALT='=&gt;'>&nbsp;&nbsp;&nbsp; <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'>&nbsp;&nbsp;&nbsp; <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_bc.gif' WIDTH=7
 HEIGHT=19 ALT='c'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-r4.html">ax-r4</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-r4.html">ax-r4</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
-WIDTH=15 HEIGHT=19 ALT='=&gt;'>&nbsp;&nbsp;&nbsp; <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'>&nbsp;&nbsp;&nbsp; <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif'
 WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG SRC='eq.gif' WIDTH=12
 HEIGHT=19 ALT='='> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-r5.html">ax-r5</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-r5.html">ax-r5</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
-WIDTH=15 HEIGHT=19 ALT='=&gt;'>&nbsp;&nbsp;&nbsp; <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'>&nbsp;&nbsp;&nbsp; <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
@@ -447,24 +443,24 @@ into orthomodular lattices.
 <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
 <CAPTION><B>Orthomodular Law</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-r3.html">ax-r3</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bc.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-r3.html">ax-r3</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
 ALIGN=TOP><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
-<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif'
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif'
 WIDTH=9 HEIGHT=19 ALT='_|_'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19
 ALT='_|_'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif'
 WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
@@ -475,8 +471,8 @@ ALIGN=TOP>
 ALT='=&gt;'>&nbsp;&nbsp;&nbsp;
 
 <!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
-<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_bb.gif'
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'></TD></TR>
 
 
@@ -501,57 +497,57 @@ variable on the right-hand side that is not on the left-hand side).
 <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
 <CAPTION><B>Some Definitions</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="df-b.html">df-b</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="df-b.html">df-b</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='equiv.gif' WIDTH=12
 HEIGHT=19 ALT='=='> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif'
 WIDTH=9 HEIGHT=19 ALT='_|_'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19
 ALT='_|_'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif'
 WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
 ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="df-a.html">df-a</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="df-a.html">df-a</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif' WIDTH=9
 HEIGHT=19 ALT='_|_'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19
 ALT='v'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
 ALIGN=TOP><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'></TD></TR>
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="df-t.html">df-t</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'> <IMG SRC='eq.gif'
+<TR ALIGN=LEFT><TD><A HREF="df-t.html">df-t</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif'
 WIDTH=9 HEIGHT=19 ALT='_|_'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="df-f.html">df-f</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='0.gif' WIDTH=8 HEIGHT=19 ALT='0'> <IMG SRC='eq.gif'
+<TR ALIGN=LEFT><TD><A HREF="df-f.html">df-f</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='0.gif' WIDTH=8 HEIGHT=19 ALT='0'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19
 ALT='1'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
 ALIGN=TOP></TD></TR>
@@ -567,15 +563,15 @@ more compactly:
 <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
 <CAPTION><B>Orthomodular Law</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="r3a.html">r3a</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'> <IMG SRC='eq.gif'
+<TR ALIGN=LEFT><TD><A HREF="r3a.html">r3a</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
 ALIGN=TOP> <IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='>
 <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
-WIDTH=5 HEIGHT=19 ALT=')'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
+WIDTH=5 HEIGHT=19 ALT=')'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp; <!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='
@@ -594,16 +590,16 @@ HREF="mmdefinitions.html">definition list</A>.
 COLOR="#006633">Relationship to Hilbert
 Space</FONT></B>&nbsp;&nbsp;&nbsp; The set of closed subspaces of
 Hilbert space, <IMG SRC='_scrch.gif' WIDTH=22 HEIGHT=19 ALT='CH'
-ALIGN=TOP>, determines a special case of an orthomodular lattice <IMG
-SRC='langle.gif' WIDTH=4 HEIGHT=19 ALT='&lt;.' ><I>A</I>, <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>, <IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'><IMG
-SRC='rangle.gif' WIDTH=4 HEIGHT=19 ALT='&gt;.' >.
+ALIGN=TOP>, determines a special case of an orthomodular lattice
+<IMG SRC='langle.gif' WIDTH=4 HEIGHT=19 ALT='&lt;.' ><I>A</I>,
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>,
+<IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19
+ALT='_|_'><IMG SRC='rangle.gif' WIDTH=4 HEIGHT=19 ALT='&gt;.' >.
 Specifically, it is the algebra <IMG SRC='langle.gif' WIDTH=4 HEIGHT=19
 ALT='&lt;.' ><IMG SRC='_scrch.gif' WIDTH=22 HEIGHT=19 ALT='CH'
 ALIGN=TOP>, <IMG SRC='_veeh.gif' WIDTH=21 HEIGHT=19 ALT='vH'>,
-<IMG SRC='perp.gif' WIDTH=11 HEIGHT=19 ALT='_|_'><IMG
-SRC='rangle.gif' WIDTH=4 HEIGHT=19 ALT='&gt;.' >, where the
+<IMG SRC='perp.gif' WIDTH=11 HEIGHT=19
+ALT='_|_'><IMG SRC='rangle.gif' WIDTH=4 HEIGHT=19 ALT='&gt;.' >, where the
 base set and operations are defined as <A
 HREF="../mpeuni/df-ch.html">df-ch</A>, <A
 HREF="../mpeuni/df-chj.html">df-chj</A>, and <A
@@ -677,22 +673,22 @@ using <A HREF="ax-r3.html">ax-r3</A>, is frequently used.
 <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
 <CAPTION><B>Orthomodular Law</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="oml.html">oml</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="oml.html">oml</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif'
 WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
@@ -705,20 +701,20 @@ algebras is that the distributive law of conjunction (AND) over
 disjunction (OR) fails, i.e., the system lacks this law.  The
 Foulis-Holland theorems (proved independently by Foulis and Holland)
 provide weak but very useful versions of the distributive law.  The
-relation "<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'> <IMG SRC='_bb.gif'
+relation "<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'>", defined as
 
 "<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
-ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif' WIDTH=10
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif'
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif'
 WIDTH=9 HEIGHT=19 ALT='_|_'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP>", is read "<IMG SRC='_ba.gif'
@@ -730,9 +726,9 @@ WIDTH=8 HEIGHT=19 ALT='b'>" (see <A HREF="df-c1.html">df-c1</A>).
 <CAPTION><B>Foulis-Holland Theorems</B></CAPTION>
 
 <TR ALIGN=LEFT><TD><A HREF="fh1.html">fh1</A></TD><TD><!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19
+ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19
 ALT='C'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;
@@ -741,24 +737,24 @@ WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19
-ALT='v'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALT='v'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
+ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
 
 <TR ALIGN=LEFT><TD><A HREF="fh2.html">fh2</A></TD><TD><!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19
+ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19
 ALT='C'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;
@@ -767,24 +763,24 @@ WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19
-ALT='v'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALT='v'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
+ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
-ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
+ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
 
 <TR ALIGN=LEFT><TD><A HREF="fh3.html">fh3</A></TD><TD><!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19
+ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19
 ALT='C'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;
@@ -794,24 +790,24 @@ ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19
 ALT='^'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
 HEIGHT=19 ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
 <TR ALIGN=LEFT><TD><A HREF="fh4.html">fh4</A></TD><TD><!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19
+ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19
 ALT='C'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;
@@ -821,17 +817,17 @@ ALT='b'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19
 ALT='^'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
 HEIGHT=19 ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif' WIDTH=10
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
@@ -846,11 +842,11 @@ strengthened by Beran.
 <CAPTION><B>Gudder-Schelp-Beran Theorem</B></CAPTION>
 
 <TR ALIGN=LEFT><TD><A HREF="gsth2.html">gsth2</A></TD><TD><!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'> <IMG
-SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19
-ALT='C'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cap.gif' WIDTH=10
+ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'>
+<IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19
+ALT='C'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
 ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
@@ -874,51 +870,51 @@ commutative "chain."
 <CAPTION><B>Marsden-Herman Distributive Law</B></CAPTION>
 
 <TR ALIGN=LEFT><TD><A HREF="mh2.html">mh2</A></TD><TD><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
-ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cc.gif' WIDTH=12
+ALT='a'> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<IMG SRC='_bb.gif'
+WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cc.gif' WIDTH=12
 HEIGHT=19 ALT='C'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
-ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'> <IMG
-SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'> <IMG SRC='cc.gif' WIDTH=12
+ALIGN=TOP> <IMG SRC='cc.gif' WIDTH=12 HEIGHT=19 ALT='C'>
+<IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<IMG SRC='_bd.gif'
+WIDTH=9 HEIGHT=19 ALT='d'> <IMG SRC='cc.gif' WIDTH=12
 HEIGHT=19 ALT='C'> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'> <IMG SRC='cup.gif' WIDTH=10
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
 HEIGHT=19 ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
-ALIGN=TOP> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
+ALIGN=TOP> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
+ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bd.gif' WIDTH=9
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bd.gif' WIDTH=9
 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif' WIDTH=7
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif' WIDTH=7
 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
-ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19
+ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
@@ -939,41 +935,41 @@ the axioms for orthomodular lattices.
 <TR ALIGN=LEFT><TD><A HREF="distid.html">distid</A></TD><TD>
 <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='
-ALIGN=TOP> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
+ALIGN=TOP> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
+ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
 HEIGHT=19 ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'> <IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='
-ALIGN=TOP> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
+ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
@@ -1000,140 +996,140 @@ the Birkhoff-von Neumann requirement.  In a Boolean algebra, these all
 reduce to classical implication <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
 ALIGN=TOP><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
-<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> (<A HREF="df-i0.html">df-i0</A>).
 
 
 <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
 <CAPTION><B>The Five Quantum Implications</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="df-i1.html">df-i1</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="df-i1.html">df-i1</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to1.gif' WIDTH=19
 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif' WIDTH=9
 HEIGHT=19 ALT='_|_'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19
 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="df-i2.html">df-i2</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="df-i2.html">df-i2</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to2.gif' WIDTH=21
 HEIGHT=19 ALT='-&gt;2'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif' WIDTH=9
 HEIGHT=19 ALT='_|_'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="df-i3.html">df-i3</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="df-i3.html">df-i3</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to3.gif' WIDTH=21
 HEIGHT=19 ALT='-&gt;3'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
 ALIGN=TOP><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
-<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif' WIDTH=9
 HEIGHT=19 ALT='_|_'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="df-i4.html">df-i4</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="df-i4.html">df-i4</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to4.gif' WIDTH=20
 HEIGHT=19 ALT='-&gt;4'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="df-i5.html">df-i5</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="df-i5.html">df-i5</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to5.gif' WIDTH=20
 HEIGHT=19 ALT='-&gt;5'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif' WIDTH=9
 HEIGHT=19 ALT='_|_'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19
 ALT='^'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
 ALIGN=TOP><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
 
 </TABLE></CENTER>
 
@@ -1166,26 +1162,26 @@ WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
 <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
-ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19
 ALT='-&gt;1'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to1.gif' WIDTH=19
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to1.gif' WIDTH=19
 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'
-ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19
 ALT='-&gt;1'> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
 
 <TR ALIGN=LEFT><TD><A HREF="ud2.html">ud2</A></TD><TD>
 <!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif'
@@ -1193,26 +1189,26 @@ WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
 <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
-ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='_to2.gif' WIDTH=21 HEIGHT=19
 ALT='-&gt;2'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='_to2.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;2'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='_to2.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;2'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to2.gif' WIDTH=21
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to2.gif' WIDTH=21
 HEIGHT=19 ALT='-&gt;2'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='_to2.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;2'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='_to2.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;2'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'> <IMG SRC='_to2.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;2'
-ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='_to2.gif' WIDTH=21 HEIGHT=19
 ALT='-&gt;2'> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
 
 <TR ALIGN=LEFT><TD><A HREF="ud3.html">ud3</A></TD><TD>
 <!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif'
@@ -1220,26 +1216,26 @@ WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
 <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
-ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='_to3.gif' WIDTH=21 HEIGHT=19
 ALT='-&gt;3'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='_to3.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;3'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='_to3.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;3'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to3.gif' WIDTH=21
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to3.gif' WIDTH=21
 HEIGHT=19 ALT='-&gt;3'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='_to3.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;3'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='_to3.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;3'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'> <IMG SRC='_to3.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;3'
-ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='_to3.gif' WIDTH=21 HEIGHT=19
 ALT='-&gt;3'> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
 
 <TR ALIGN=LEFT><TD><A HREF="ud4.html">ud4</A></TD><TD>
 <!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif'
@@ -1247,26 +1243,26 @@ WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
 <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
-ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='_to4.gif' WIDTH=20 HEIGHT=19
 ALT='-&gt;4'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='_to4.gif' WIDTH=20 HEIGHT=19 ALT='-&gt;4'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='_to4.gif' WIDTH=20 HEIGHT=19 ALT='-&gt;4'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to4.gif' WIDTH=20
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to4.gif' WIDTH=20
 HEIGHT=19 ALT='-&gt;4'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='_to4.gif' WIDTH=20 HEIGHT=19 ALT='-&gt;4'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='_to4.gif' WIDTH=20 HEIGHT=19 ALT='-&gt;4'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'> <IMG SRC='_to4.gif' WIDTH=20 HEIGHT=19 ALT='-&gt;4'
-ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='_to4.gif' WIDTH=20 HEIGHT=19
 ALT='-&gt;4'> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
 
 <TR ALIGN=LEFT><TD><A HREF="ud5.html">ud5</A></TD><TD>
 <!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif'
@@ -1274,26 +1270,26 @@ WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
 <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
-ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='_to5.gif' WIDTH=20 HEIGHT=19
 ALT='-&gt;5'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='_to5.gif' WIDTH=20 HEIGHT=19 ALT='-&gt;5'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='_to5.gif' WIDTH=20 HEIGHT=19 ALT='-&gt;5'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to5.gif' WIDTH=20
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to5.gif' WIDTH=20
 HEIGHT=19 ALT='-&gt;5'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='_to5.gif' WIDTH=20 HEIGHT=19 ALT='-&gt;5'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='_to5.gif' WIDTH=20 HEIGHT=19 ALT='-&gt;5'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'> <IMG SRC='_to5.gif' WIDTH=20 HEIGHT=19 ALT='-&gt;5'
-ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
+ALT='a'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='_to5.gif' WIDTH=20 HEIGHT=19
 ALT='-&gt;5'> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'></TD></TR>
 
 </TABLE></CENTER>
 
@@ -1316,61 +1312,61 @@ HREF="ax-r3.html">ax-r3</A>.
 <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
 <CAPTION><B>Weakly Orthomodular Law Equivalents</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="ax-wom.html">ax-wom</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="ax-wom.html">ax-wom</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif' WIDTH=9
 HEIGHT=19 ALT='_|_'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19
 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
-WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
+WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp; <!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif' WIDTH=9
 HEIGHT=19 ALT='_|_'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19
 ALT='^'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
 ALIGN=TOP><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19
 ALT='1'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="woml6.html">woml6</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<TR ALIGN=LEFT><TD><A HREF="woml6.html">woml6</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='supperp.gif'
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='supperp.gif'
 WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='_to2.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;2'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='_to2.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;2'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='
 ALIGN=TOP> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="ka4ot.html">ka4ot</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<TR ALIGN=LEFT><TD><A HREF="ka4ot.html">ka4ot</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='supperp.gif'
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='supperp.gif'
 WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif'
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif'
 WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif' WIDTH=7
 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP> <IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='>
@@ -1378,8 +1374,8 @@ ALIGN=TOP> <IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='>
 WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19
 ALT='1'></TD></TR>
 
@@ -1393,8 +1389,8 @@ The analogous theorem is created by replacing
 with
 "<IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='>"
 in an orthomodular lattice theorem, then suffixing it with
-"<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'>".  This
+"<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'>".  This
 means that
 the axiom system for for orthomodular lattices
 can effectively be embedded in a strictly weaker subset of itself!
@@ -1419,103 +1415,103 @@ page referenced by the hyperlink; note that
 <CAPTION><B>Weakly Orthomodular Structural Analogs for Orthomodular Lattice
 Axioms</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="wa1.html">wa1</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="wa1.html">wa1</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='equiv.gif' WIDTH=12
 HEIGHT=19 ALT='=='> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
 ALIGN=TOP><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
 WIDTH=7 HEIGHT=19 ALT='1'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="wa2.html">wa2</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<TR ALIGN=LEFT><TD><A HREF="wa2.html">wa2</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='equiv.gif'
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='equiv.gif'
 WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='
 ALIGN=TOP> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="wa3.html">wa3</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<TR ALIGN=LEFT><TD><A HREF="wa3.html">wa3</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
 WIDTH=7 HEIGHT=19 ALT='1'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="wa4.html">wa4</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<TR ALIGN=LEFT><TD><A HREF="wa4.html">wa4</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif'
 WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19
 ALT='_|_'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19
+ALT='_|_'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
 HEIGHT=19 ALT='='> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="wa5.html">wa5</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<TR ALIGN=LEFT><TD><A HREF="wa5.html">wa5</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif'
 WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='equiv.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19
+ALT='_|_'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='equiv.gif'
 WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG
-SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'></TD></TR>
+ALIGN=TOP> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='>
+<IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="wr1.html">wr1</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="wr1.html">wr1</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='equiv.gif' WIDTH=12
 HEIGHT=19 ALT='=='> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
-WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
+WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp; <!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
@@ -1525,23 +1521,23 @@ WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
 HEIGHT=19 ALT='='> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="wr2.html">wr2</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="wr2.html">wr2</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='equiv.gif' WIDTH=12
 HEIGHT=19 ALT='=='> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
 WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
-WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='equiv.gif' WIDTH=12
 HEIGHT=19 ALT='=='> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
-WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
+WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp; <!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
@@ -1551,63 +1547,63 @@ WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
 HEIGHT=19 ALT='='> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="wr3.html">wr3</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='1.gif'
+<TR ALIGN=LEFT><TD><A HREF="wr3.html">wr3</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='1.gif'
 WIDTH=7 HEIGHT=19 ALT='1'> <IMG SRC='equiv.gif' WIDTH=12
 HEIGHT=19 ALT='=='> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
-WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
+WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp; <!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='
 ALIGN=TOP> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="wr4.html">wr4</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="wr4.html">wr4</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='equiv.gif' WIDTH=12
 HEIGHT=19 ALT='=='> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
-WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
+WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp; <!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
 ALIGN=TOP><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>
-<IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif'
+<IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif'
 WIDTH=9 HEIGHT=19 ALT='_|_'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
 ALT='='> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'
 ALIGN=TOP></TD></TR>
 
-<TR ALIGN=LEFT><TD><A HREF="wr5.html">wr5</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<TR ALIGN=LEFT><TD><A HREF="wr5.html">wr5</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='equiv.gif' WIDTH=12
 HEIGHT=19 ALT='=='> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
 <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
-WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
+WIDTH=7 HEIGHT=19 ALT='1'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp; <!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'> <IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif'
 WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif' WIDTH=7
 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
 WIDTH=7 HEIGHT=19 ALT='1'></TD></TR>
 
 
@@ -1640,25 +1636,25 @@ axiom.  Such are the surprises to be found in quantum logic.
 <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
 <CAPTION><B>Faux orthomodular law</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="woml.html">woml</A></TD><TD> <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<TR ALIGN=LEFT><TD><A HREF="woml.html">woml</A></TD><TD> <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='supperp.gif'
 WIDTH=9 HEIGHT=19 ALT='_|_'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='equiv.gif' WIDTH=12 HEIGHT=19 ALT='=='> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='eq.gif' WIDTH=12
 HEIGHT=19 ALT='='> <IMG SRC='1.gif' WIDTH=7 HEIGHT=19 ALT='1'
 ALIGN=TOP></TD></TR>
@@ -1683,8 +1679,8 @@ calculus).  Thus, for example, the law of excluded middle
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='1.gif'
 WIDTH=7 HEIGHT=19 ALT='1'>
 
 (which is a theorem of quantum logic that follows from <A
@@ -1710,8 +1706,8 @@ HREF="#PavMeg1999">[PavMeg1999]</A>.
 
 <P>Quantum propositional calculus can be formalized with modus ponens as
 its sole rule of inference,and negation and implication as its sole
-primitive connectives, as long as we use for the implication either <IMG
-SRC='_to0.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;0'> (<A
+primitive connectives, as long as we use for the implication either
+<IMG SRC='_to0.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;0'> (<A
 HREF="wi0.html">wi0</A>) or <IMG SRC='_to3.gif' WIDTH=21 HEIGHT=19
 ALT='-&gt;3'> (<A HREF="wi3.html">wi3</A>).  Kalmbach proved
 that these are the only two implications that work.  We prove soundness
@@ -1757,11 +1753,11 @@ ALIGN=TOP><I>z</I>) fails in this lattice:  Let <I>x</I>=<I>a</I>,
 <I>y</I>=<I>b</I>, <I>z</I>=<I>b</I><IMG SRC='supperp.gif' WIDTH=9
 HEIGHT=19 ALT='_|_'>.  Then <I>x</I><IMG SRC='cap.gif'
 WIDTH=10 HEIGHT=19 ALT='^'>(<I>y</I><IMG SRC='cup.gif'
-WIDTH=10 HEIGHT=19 ALT='v'><I>z</I>)=<I>a</I><IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>(<I>b</I><IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'><I>b</I><IMG
-SRC='supperp.gif' WIDTH=9 HEIGHT=19 ALT='_|_'>)=<I>a</I><IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>1=<I>a</I>, but
+WIDTH=10 HEIGHT=19 ALT='v'><I>z</I>)=<I>a</I><IMG SRC='cap.gif'
+WIDTH=10 HEIGHT=19 ALT='^'>(<I>b</I><IMG SRC='cup.gif'
+WIDTH=10 HEIGHT=19 ALT='v'><I>b</I><IMG SRC='supperp.gif'
+WIDTH=9 HEIGHT=19 ALT='_|_'>)=<I>a</I><IMG SRC='cap.gif'
+WIDTH=10 HEIGHT=19 ALT='^'>1=<I>a</I>, but
 (<I>x</I><IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
 ALIGN=TOP><I>y</I>)<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
 ALIGN=TOP>(<I>x</I><IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
@@ -1827,96 +1823,96 @@ HEIGHT=19 ALT='=&lt;'>".)
 <TR ALIGN=LEFT><TD><A HREF="ax-3oa.html">ax-3oa</A></TD><TD>
 <!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19
 ALT='-&gt;1'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG
-SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'>
+<IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='le.gif' WIDTH=11
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='le.gif' WIDTH=11
 HEIGHT=19 ALT='=&lt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
 <TR ALIGN=LEFT><TD><A HREF="ax-4oa.html">ax-4oa</A></TD><TD>
 <!-- <IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bd.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bd.gif'
 WIDTH=9 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG
-SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'>
+<IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='_to1.gif' WIDTH=19
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='_to1.gif' WIDTH=19
 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9
 HEIGHT=19 ALT='a'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19
 ALT='-&gt;1'> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
-ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG
-SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'>
+<IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG
-SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'>
+<IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'> <IMG SRC='_to1.gif' WIDTH=19
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'> <IMG SRC='_to1.gif' WIDTH=19
 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5
 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='le.gif' WIDTH=11
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='le.gif' WIDTH=11
 HEIGHT=19 ALT='=&lt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bd.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bd.gif'
 WIDTH=9 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
@@ -1932,88 +1928,88 @@ law as a theorem derived from 4OA.
 <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
 <CAPTION><B>Original 6-variable Orthoarguesian Law</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="oa6.html">oa6</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='le.gif'
+<TR ALIGN=LEFT><TD><A HREF="oa6.html">oa6</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='le.gif'
 WIDTH=11 HEIGHT=19 ALT='=&lt;'> <IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19
 ALT='_|_'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif' WIDTH=12
-HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'> <IMG SRC='le.gif'
+HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'> <IMG SRC='le.gif'
 WIDTH=11 HEIGHT=19 ALT='=&lt;'> <IMG SRC='_bd.gif' WIDTH=9
 HEIGHT=19 ALT='d'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19
 ALT='_|_'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif' WIDTH=12
-HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_be.gif' WIDTH=8 HEIGHT=19 ALT='e'> <IMG SRC='le.gif'
+HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_be.gif' WIDTH=8 HEIGHT=19 ALT='e'> <IMG SRC='le.gif'
 WIDTH=11 HEIGHT=19 ALT='=&lt;'> <IMG SRC='_bf.gif' WIDTH=9
 HEIGHT=19 ALT='f'><IMG SRC='supperp.gif' WIDTH=9 HEIGHT=19
 ALT='_|_'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif' WIDTH=15
-HEIGHT=19 ALT='=&gt;'>&nbsp;&nbsp;&nbsp; <!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+HEIGHT=19 ALT='=&gt;'>&nbsp;&nbsp;&nbsp; <!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bd.gif'
+ALIGN=TOP><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bd.gif'
 WIDTH=9 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_be.gif'
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_be.gif'
 WIDTH=8 HEIGHT=19 ALT='e'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bf.gif' WIDTH=9 HEIGHT=19
 ALT='f'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='le.gif' WIDTH=11 HEIGHT=19 ALT='=&lt;'> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='le.gif' WIDTH=11 HEIGHT=19 ALT='=&lt;'> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif'
 WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bd.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bd.gif'
 WIDTH=9 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_be.gif' WIDTH=8 HEIGHT=19 ALT='e'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_be.gif' WIDTH=8 HEIGHT=19 ALT='e'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bf.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bf.gif'
 WIDTH=9 HEIGHT=19 ALT='f'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='_be.gif' WIDTH=8 HEIGHT=19 ALT='e'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif'
+ALIGN=TOP> <IMG SRC='_be.gif' WIDTH=8 HEIGHT=19
+ALT='e'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif'
 WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='_bf.gif' WIDTH=9 HEIGHT=19 ALT='f'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='_bf.gif' WIDTH=9 HEIGHT=19 ALT='f'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'></TD></TR>
 
@@ -2033,131 +2029,131 @@ law.
 <P><CENTER><TABLE BORDER CELLSPACING=0 BGCOLOR="#EEFFFA">
 <CAPTION><B>3OA and 4OA Distributive Laws</B></CAPTION>
 
-<TR ALIGN=LEFT><TD><A HREF="oadistd.html">oadistd</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'> <IMG SRC='le.gif'
+<TR ALIGN=LEFT><TD><A HREF="oadistd.html">oadistd</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'> <IMG SRC='le.gif'
 WIDTH=11 HEIGHT=19 ALT='=&lt;'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
 ALIGN=TOP> <IMG SRC='_to2.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;2'
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='_be.gif' WIDTH=8 HEIGHT=19
 ALT='e'> <IMG SRC='le.gif' WIDTH=11 HEIGHT=19 ALT='=&lt;'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='_to0.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;0'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<IMG SRC='_to0.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;0'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='_to2.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;2'
-ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif'
+ALIGN=TOP> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
+ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif'
 WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
 ALIGN=TOP> <IMG SRC='_to2.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;2'
-ALIGN=TOP> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
+ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif' WIDTH=12
-HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_bf.gif' WIDTH=9 HEIGHT=19 ALT='f'> <IMG SRC='le.gif'
+HEIGHT=19 ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_bf.gif' WIDTH=9 HEIGHT=19 ALT='f'> <IMG SRC='le.gif'
 WIDTH=11 HEIGHT=19 ALT='=&lt;'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG
-SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'>
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'> <IMG SRC='_to0.gif' WIDTH=21 HEIGHT=19 ALT='-&gt;0'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to2.gif' WIDTH=21
 HEIGHT=19 ALT='-&gt;2'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to2.gif' WIDTH=21
 HEIGHT=19 ALT='-&gt;2'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to2.gif' WIDTH=21
 HEIGHT=19 ALT='-&gt;2'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='le.gif' WIDTH=11 HEIGHT=19 ALT='=&lt;'> <IMG
-SRC='_bf.gif' WIDTH=9 HEIGHT=19 ALT='f'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='le.gif' WIDTH=11 HEIGHT=19 ALT='=&lt;'>
+<IMG SRC='_bf.gif' WIDTH=9 HEIGHT=19 ALT='f'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp; <!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_be.gif'
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_be.gif'
 WIDTH=8 HEIGHT=19 ALT='e'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bf.gif' WIDTH=9 HEIGHT=19
 ALT='f'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='_be.gif' WIDTH=8 HEIGHT=19 ALT='e'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='_be.gif' WIDTH=8 HEIGHT=19 ALT='e'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bf.gif'
+ALIGN=TOP><IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bf.gif'
 WIDTH=9 HEIGHT=19 ALT='f'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 
 
-<TR ALIGN=LEFT><TD><A HREF="4oadist.html">4oadist</A></TD><TD><!-- <IMG
-SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG
-SRC='_be.gif' WIDTH=8 HEIGHT=19 ALT='e'> <IMG SRC='eq.gif'
+<TR ALIGN=LEFT><TD><A HREF="4oadist.html">4oadist</A></TD><TD><!--
+<IMG SRC='_vdash.gif' WIDTH=10 HEIGHT=19 ALT='|-'> -->
+<IMG SRC='_be.gif' WIDTH=8 HEIGHT=19 ALT='e'> <IMG SRC='eq.gif'
 WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif'
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif'
 WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif' WIDTH=7
 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+ALIGN=TOP> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'
-ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif'
+ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19
+ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif'
 WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
 ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'
-ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19
+ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19
 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'
-ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif'
+ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19
+ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif'
 WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'
 ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'
-ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19
+ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif' WIDTH=12 HEIGHT=19
@@ -2165,32 +2161,32 @@ ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif'
 WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='_bf.gif' WIDTH=9
 HEIGHT=19 ALT='f'> <IMG SRC='eq.gif' WIDTH=12 HEIGHT=19
 ALT='='> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
+ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19
 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
-<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
+<IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19
 ALT='a'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'
-ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif'
+ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19
+ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif'
 WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
 ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'
-ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19 ALT='d'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='_bd.gif' WIDTH=9 HEIGHT=19
+ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'> <IMG SRC='cup.gif' WIDTH=10 HEIGHT=19 ALT='v'
-ALIGN=TOP> <IMG SRC='_be.gif' WIDTH=8 HEIGHT=19 ALT='e'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='amp.gif' WIDTH=12 HEIGHT=19 ALT='&amp;'
+ALIGN=TOP> <IMG SRC='_be.gif' WIDTH=8 HEIGHT=19
+ALT='e'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif'
+WIDTH=12 HEIGHT=19 ALT='&amp;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='_bh.gif' WIDTH=10 HEIGHT=19
 ALT='h'> <IMG SRC='le.gif' WIDTH=11 HEIGHT=19 ALT='=&lt;'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to1.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG SRC='_to1.gif'
 WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bd.gif' WIDTH=9
 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp;<IMG SRC='amp.gif' WIDTH=12 HEIGHT=19
@@ -2208,32 +2204,32 @@ ALT='&amp;'>&nbsp;&nbsp;&nbsp;<!-- <IMG SRC='_vdash.gif'
 WIDTH=10 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='_bh.gif' WIDTH=10 HEIGHT=19
 ALT='h'> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'
-ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG
-SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='_to1.gif'
+ALIGN=TOP> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
+ALT='('><IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'> <IMG SRC='_to1.gif'
 WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bd.gif' WIDTH=9
 HEIGHT=19 ALT='d'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='le.gif' WIDTH=11 HEIGHT=19 ALT='=&lt;'> <IMG
-SRC='_bk.gif' WIDTH=9 HEIGHT=19 ALT='k'>&nbsp;&nbsp;&nbsp;<IMG
-SRC='bigto.gif' WIDTH=15 HEIGHT=19 ALT='=&gt;'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='le.gif' WIDTH=11 HEIGHT=19 ALT='=&lt;'>
+<IMG SRC='_bk.gif' WIDTH=9 HEIGHT=19 ALT='k'>&nbsp;&nbsp;&nbsp;<IMG SRC='bigto.gif'
+WIDTH=15 HEIGHT=19 ALT='=&gt;'
 ALIGN=TOP>&nbsp;&nbsp;&nbsp; <!-- <IMG SRC='_vdash.gif' WIDTH=10
 HEIGHT=19 ALT='|-'> --> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_bh.gif' WIDTH=10 HEIGHT=19 ALT='h'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bj.gif'
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bj.gif'
 WIDTH=7 HEIGHT=19 ALT='j'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='_bk.gif' WIDTH=9 HEIGHT=19
 ALT='k'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG
-SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='lp.gif'
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'>
+<IMG SRC='eq.gif' WIDTH=12 HEIGHT=19 ALT='='> <IMG SRC='lp.gif'
 WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19
 ALT='('><IMG SRC='_bh.gif' WIDTH=10 HEIGHT=19 ALT='h'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='_bj.gif' WIDTH=7 HEIGHT=19 ALT='j'><IMG SRC='rp.gif'
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='_bj.gif' WIDTH=7 HEIGHT=19 ALT='j'><IMG SRC='rp.gif'
 WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cup.gif' WIDTH=10
 HEIGHT=19 ALT='v'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bh.gif' WIDTH=10 HEIGHT=19 ALT='h'> <IMG
-SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bk.gif'
+ALIGN=TOP><IMG SRC='_bh.gif' WIDTH=10 HEIGHT=19 ALT='h'>
+<IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG SRC='_bk.gif'
 WIDTH=9 HEIGHT=19 ALT='k'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
 ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
@@ -2295,30 +2291,30 @@ SUMMARY="Assertion">
 <CAPTION><B>A New Axiom Extending Quantum Logic</B></CAPTION>
 <TR ALIGN=LEFT><TD><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5
 HEIGHT=19 ALT='('><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bb.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bb.gif'
 WIDTH=8 HEIGHT=19 ALT='b'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bc.gif' WIDTH=7
+ALIGN=TOP> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bc.gif' WIDTH=7
 HEIGHT=19 ALT='c'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19
 ALT='-&gt;1'> <IMG SRC='_bb.gif' WIDTH=8 HEIGHT=19 ALT='b'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='cap.gif' WIDTH=10
 HEIGHT=19 ALT='^'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
 ALIGN=TOP><IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'> <IMG
-SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bc.gif'
+ALIGN=TOP><IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'>
+<IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_bc.gif'
 WIDTH=7 HEIGHT=19 ALT='c'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
-ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'> <IMG
-SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8
+ALIGN=TOP> <IMG SRC='cap.gif' WIDTH=10 HEIGHT=19 ALT='^'>
+<IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('><IMG SRC='_bb.gif' WIDTH=8
 HEIGHT=19 ALT='b'> <IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19
 ALT='-&gt;1'> <IMG SRC='_ba.gif' WIDTH=9 HEIGHT=19 ALT='a'
-ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'><IMG
-SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='le.gif' WIDTH=11
+ALIGN=TOP><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19
+ALT=')'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'> <IMG SRC='le.gif' WIDTH=11
 HEIGHT=19 ALT='=&lt;'> <IMG SRC='lp.gif' WIDTH=5 HEIGHT=19 ALT='('
-ALIGN=TOP><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'> <IMG
-SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_ba.gif'
+ALIGN=TOP><IMG SRC='_bc.gif' WIDTH=7 HEIGHT=19 ALT='c'>
+<IMG SRC='_to1.gif' WIDTH=19 HEIGHT=19 ALT='-&gt;1'> <IMG SRC='_ba.gif'
 WIDTH=9 HEIGHT=19 ALT='a'><IMG SRC='rp.gif' WIDTH=5 HEIGHT=19 ALT=')'
 ALIGN=TOP></TD></TR>
 </TABLE></CENTER>


### PR DESCRIPTION
This ensures that the [heuristic](https://github.com/metamath/metamath-website-scripts/blob/8d81a0c1ab3e433b335b4e6a3bdc364d277b4946/build-website.sh#L133) for image referencing works as intended. There are other more complicated ways to fix this, but the set of pages to deal with is relatively small and finite so it seems fine to just do this for now.

Reported at https://groups.google.com/g/metamath/c/P0D4h2uIj2k/m/gN516opbBwAJ .