### PR TITLE
Updated set.mm proof count (over 40,000) and page last updated date

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@ See the <A HREF="#faq">FAQ</A> for more information.
 <!-- </SPAN> -->
 
 - Constructs mathematics from scratch, starting from
-ZFC set theory axioms.  Over 23,000 proofs.
+ZFC set theory axioms.  Over 40,000 proofs.
 
 <FONT SIZE=-1>
 
@@ -1831,7 +1831,7 @@ SIZE=-1>Rated by JARS (Apr. 26, 1998)</FONT></TD>
 <HR NOSHADE SIZE=1>
 
 <CENTER><I><FONT SIZE=-1>This page was
-last updated on 7-Aug-2021.</FONT></I></CENTER>
+last updated on 17-Nov-2024.</FONT></I></CENTER>
 
 
 <TABLE BORDER=0 WIDTH="100%"><TR>


### PR DESCRIPTION
Just two little updates on index.html (by hand):

- set.mm now has "Over 40,000 proofs" (estimated just yesterday, see my countmmproofs repo: <https://www.github.com/BismaBRJ/countmmproofs>). Previously it was "Over 23,000 proofs". Honestly I just made a small C program to count the number of $= tokens (which, as far as I know, should appear exactly once in every proof) in the set.mm database of the recent commit [2813f8eb3a62e829c4c7afea58513c2d77d4c98f](https://www.github.com/metamath/set.mm/commit/2813f8eb3a62e829c4c7afea58513c2d77d4c98f), which I found to be exactly 43565. Assuming some of those occurrences of $= may be in comments, I only dare say "Over 40,000 proofs"

- the bottom of the page now says "This page was last updated on 17-Nov-2024". Previously it was "This page was last updated on 7-Aug-2021" even though it has been updated numerous times. I first noticed because the death of Norman "Norm" Dwight Megill, Ph.D. on December 9, 2021 is already announced on this index page, even though that is after 7-Aug-2021

I may be a nobody but I do hope that every change on index.html from now on will not forget to update that "This page was last updated on" date. Hopefully it will help with the impression of Metamath, that it is still alive to this day. Also, I plan to cite this page on my bachelor's thesis :)

Feel free to correct me, and thanks to all contributors!