### PR TITLE
Fix metamath-knife GitHub link

### DIFF
--- a/other.html
+++ b/other.html
@@ -338,7 +338,7 @@ HREF="https://web.archive.org/web/20131219001737/http://wiki.planetmath.org/cgi-
  wiki page</A> [retrieved 3-Aug-2016] as of 2011.
  </LI>
 
-<li><a name="metamath-knife"></a><a href=https://github.com/david-a-wheeler/metamath-knife">Metamath-knife</a> - Metamath system written in Rust, a fork of metamath-rs (below).</li>
+<li><a name="metamath-knife"></a><a href="https://github.com/david-a-wheeler/metamath-knife">Metamath-knife</a> - Metamath system written in Rust, a fork of metamath-rs (below).</li>
 
 <LI> <A NAME="leanmmverify"></A> <A
 HREF="https://github.com/digama0/mm-lean4/">mm-lean4</A>


### PR DESCRIPTION
Adds a missing quote so that the link correctly points to GitHub repo instead of 404 page.