### PR TITLE
Optimize checkmm.cpp

### DIFF
--- a/downloads/checkmm.cpp
+++ b/downloads/checkmm.cpp
@@ -37,7 +37,6 @@
 #include <iostream>
 #include <iterator>
 #include <limits>
-#include <map>
 #include <queue>
 #include <set>
 #include <string>

--- a/downloads/checkmm.cpp
+++ b/downloads/checkmm.cpp
@@ -42,6 +42,8 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace
@@ -49,7 +51,7 @@ namespace
 
 std::queue<std::string> tokens;
 
-std::set<std::string> constants;
+std::unordered_set<std::string> constants;
 
 typedef std::vector<std::string> Expression;
 
@@ -57,9 +59,9 @@ typedef std::vector<std::string> Expression;
 // true iff the hypothesis is floating.
 typedef std::pair<Expression, bool> Hypothesis;
 
-std::map<std::string, Hypothesis> hypotheses;
+std::unordered_map<std::string, Hypothesis> hypotheses;
 
-std::set<std::string> variables;
+std::unordered_set<std::string> variables;
 
 // An axiom or a theorem.
 struct Assertion
@@ -71,16 +73,16 @@ struct Assertion
     Expression expression;
 };
 
-std::map<std::string, Assertion> assertions;
+std::unordered_map<std::string, Assertion> assertions;
 
 struct Scope
 {
-    std::set<std::string> activevariables;
+    std::unordered_set<std::string> activevariables;
     // Labels of active hypotheses
     std::vector<std::string> activehyp;
     std::vector<std::set<std::string> > disjvars;
     // Map from variable to label of active floating hypothesis
-    std::map<std::string, std::string> floatinghyp;
+    std::unordered_map<std::string, std::string> floatinghyp;
 };
 
 std::vector<Scope> scopes;
@@ -99,7 +101,7 @@ std::string getfloatinghyp(std::string const var)
     for (std::vector<Scope>::const_iterator iter(scopes.begin());
          iter != scopes.end(); ++iter)
     {
-        std::map<std::string, std::string>::const_iterator const loc
+        std::unordered_map<std::string, std::string>::const_iterator const loc
             (iter->floatinghyp.find(var));
         if (loc != iter->floatinghyp.end())
             return loc->second;
@@ -389,16 +391,16 @@ Assertion & constructassertion(std::string const label, Expression const & exp)
         for (std::vector<std::set<std::string> >::const_iterator iter2
             (disjvars.begin()); iter2 != disjvars.end(); ++iter2)
         {
-            std::set<std::string> dset;
+            std::unordered_set<std::string> dset;
             std::set_intersection
                  (iter2->begin(), iter2->end(),
                   varsused.begin(), varsused.end(),
                   std::inserter(dset, dset.end()));
 
-            for (std::set<std::string>::const_iterator diter(dset.begin());
+            for (std::unordered_set<std::string>::const_iterator diter(dset.begin());
                  diter != dset.end(); ++diter)
             {
-                std::set<std::string>::const_iterator diter2(diter);
+                std::unordered_set<std::string>::const_iterator diter2(diter);
                 ++diter2;
                 for (; diter2 != dset.end(); ++diter2)
                     assertion.disjvars.insert(std::make_pair(*diter, *diter2));
@@ -468,14 +470,14 @@ bool readexpression
 // Make a substitution of variables. The result is put in "destination",
 // which should be empty.
 void makesubstitution
-    (Expression const & original, std::map<std::string, Expression> const & substmap,
+    (Expression const & original, std::unordered_map<std::string, Expression> const & substmap,
      Expression * destination
     )
 {
     for (Expression::const_iterator iter(original.begin());
          iter != original.end(); ++iter)
     {
-        std::map<std::string, Expression>::const_iterator const iter2
+        std::unordered_map<std::string, Expression>::const_iterator const iter2
             (substmap.find(*iter));
         if (iter2 == substmap.end())
         {
@@ -572,7 +574,7 @@ bool verifyassertionref(std::string thlabel, std::string reflabel,
     std::vector<Expression>::size_type const base
         (stack->size() - assertion.hypotheses.size());
 
-    std::map<std::string, Expression> substitutions;
+    std::unordered_map<std::string, Expression> substitutions;
 
     // Determine substitutions and check that we can unify
     for (std::deque<std::string>::size_type i(0);
@@ -592,8 +594,8 @@ bool verifyassertionref(std::string thlabel, std::string reflabel,
             Expression & subst(substitutions.insert
                 (std::make_pair(hypothesis.first[1],
                  Expression())).first->second);
-            std::copy((*stack)[base + i].begin() + 1, (*stack)[base + i].end(),
-                      std::back_inserter(subst));
+            Expression & substee = (*stack)[base + i];
+            subst.insert(subst.end(), substee.begin() + 1, substee.end());
         }
         else
         {
@@ -620,7 +622,7 @@ bool verifyassertionref(std::string thlabel, std::string reflabel,
         Expression const & exp1(substitutions.find(iter->first)->second);
         Expression const & exp2(substitutions.find(iter->second)->second);
 
-        std::set<std::string> exp1vars;
+        std::unordered_set<std::string> exp1vars;
         for (Expression::const_iterator exp1iter(exp1.begin());
              exp1iter != exp1.end(); ++exp1iter)
         {
@@ -628,7 +630,7 @@ bool verifyassertionref(std::string thlabel, std::string reflabel,
                 exp1vars.insert(*exp1iter);
         }
 
-        std::set<std::string> exp2vars;
+        std::unordered_set<std::string> exp2vars;
         for (Expression::const_iterator exp2iter(exp2.begin());
              exp2iter != exp2.end(); ++exp2iter)
         {
@@ -636,10 +638,10 @@ bool verifyassertionref(std::string thlabel, std::string reflabel,
                 exp2vars.insert(*exp2iter);
         }
 
-        for (std::set<std::string>::const_iterator exp1iter
+        for (std::unordered_set<std::string>::const_iterator exp1iter
             (exp1vars.begin()); exp1iter != exp1vars.end(); ++exp1iter)
         {
-            for (std::set<std::string>::const_iterator exp2iter
+            for (std::unordered_set<std::string>::const_iterator exp2iter
                 (exp2vars.begin()); exp2iter != exp2vars.end(); ++exp2iter)
             {
                 if (!isdvr(*exp1iter, *exp2iter))
@@ -673,7 +675,7 @@ bool verifyregularproof
          proofstep != proof.end(); ++proofstep)
     {
         // If step is a hypothesis, just push it onto the stack.
-        std::map<std::string, Hypothesis>::const_iterator hyp
+        std::unordered_map<std::string, Hypothesis>::const_iterator hyp
             (hypotheses.find(*proofstep));
         if (hyp != hypotheses.end())
         {
@@ -738,7 +740,7 @@ bool verifycompressedproof
 
             // If step is a (non-mandatory) hypothesis,
             // just push it onto the stack.
-            std::map<std::string, Hypothesis>::const_iterator hyp
+            std::unordered_map<std::string, Hypothesis>::const_iterator hyp
             (hypotheses.find(proofstep));
             if (hyp != hypotheses.end())
             {


### PR DESCRIPTION
by using unordered rather than ordered containers in places, and in one case a slightly more efficient means of insert.

Initially for the attention of the author, @EricSchmidt-119 , please.  Originally discussed [here](https://groups.google.com/g/metamath/c/v7XfItwXuNw), but I did slightly more before [achieving my optimization goal](https://groups.google.com/g/metamath/c/RQX4HPaq954/m/kmznS3KOBAAJ).  It passes the [metamath-test](https://github.com/david-a-wheeler/metamath-test/) suite, of course.